### PR TITLE
Better support for including as subproject (resolves #11)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,6 @@ project(
 	]
 )
 
-
 compiler = meson.get_compiler('cpp')
 message(['compiler ID: ', compiler.get_id()])
 
@@ -73,7 +72,16 @@ compiler_supports_char8_strings = compiler.compiles('''
 	args : [ '-std=c++2a' ]
 )
 
-inc = include_directories(['include', 'extern'])
+tomlplusplus_dep = declare_dependency(
+	include_directories : include_directories('include'),
+	version : meson.project_version(),
+)
 
-subdir('tests')
+if get_option('BUILD_TESTS')
+	inc = include_directories('include', 'extern')
+	subdir('tests')
+else
+	message('Not building tests')
+endif
+
 # subdir('examples')

--- a/meson.build
+++ b/meson.build
@@ -77,7 +77,14 @@ tomlplusplus_dep = declare_dependency(
 	version : meson.project_version(),
 )
 
-if get_option('BUILD_TESTS')
+build_tests = false
+if get_option('BUILD_TESTS').auto()
+	build_tests = (not meson.is_subproject())
+else
+	build_tests = get_option('BUILD_TESTS').enabled()
+endif
+
+if build_tests
 	inc = include_directories('include', 'extern')
 	subdir('tests')
 else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('BUILD_TESTS', type : 'boolean', value : false, description : 'Whether to build tests')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,1 @@
-option('BUILD_TESTS', type : 'boolean', value : false, description : 'Whether to build tests')
+option('BUILD_TESTS', type : 'feature', value : 'auto', description : 'Whether to build tests (defaults to auto: only if not a subproject)')


### PR DESCRIPTION
 * Define tomlplusplus_dep for when included in subproject.
 * Added option BUILD_TESTS, default false.
