### PR TITLE
Fix build with GCC 8.2.0

### DIFF
--- a/include/toml++/toml_parser_impl.h
+++ b/include/toml++/toml_parser_impl.h
@@ -221,8 +221,8 @@ TOML_IMPL_START
 						recording_buffer.clear();
 					else
 						recording_buffer.erase(
-							recording_buffer.cbegin() + static_cast<ptrdiff_t>(recording_buffer.length() - pop_bytes),
-							recording_buffer.cend()
+							recording_buffer.begin() + static_cast<ptrdiff_t>(recording_buffer.length() - pop_bytes),
+							recording_buffer.end()
 						);
 				}
 			}

--- a/toml.hpp
+++ b/toml.hpp
@@ -6374,8 +6374,8 @@ TOML_IMPL_START
 						recording_buffer.clear();
 					else
 						recording_buffer.erase(
-							recording_buffer.cbegin() + static_cast<ptrdiff_t>(recording_buffer.length() - pop_bytes),
-							recording_buffer.cend()
+							recording_buffer.begin() + static_cast<ptrdiff_t>(recording_buffer.length() - pop_bytes),
+							recording_buffer.end()
 						);
 				}
 			}


### PR DESCRIPTION
For some reason, GCC 8.2.0's glibc has the pre-c++11 overloads of `std::string::erase()` which take a non-const iterator. This change fixes building on that compiler, and should also work on later versions (tested with Clang 9.0.1).