### PR TITLE
Add more VS debug visualizers

### DIFF
--- a/vs/toml++.natvis
+++ b/vs/toml++.natvis
@@ -50,4 +50,47 @@
 		<DisplayString>{&amp;bytes,s8} ({position})</DisplayString>
 	</Type>
 
+	<Type Name="::toml::table">
+		<DisplayString>{values}</DisplayString>
+		<Expand>
+			<!-- Modified from std::map visualizer in VS 2019 stl.natvis -->
+			<TreeItems>
+				<Size>values._Mypair._Myval2._Myval2._Mysize</Size>
+				<HeadPointer>values._Mypair._Myval2._Myval2._Myhead-&gt;_Parent</HeadPointer>
+				<LeftPointer>_Left</LeftPointer>
+				<RightPointer>_Right</RightPointer>
+				<ValueNode Condition="_Isnil == 0" Name="[{_Myval.first}]">*_Myval.second</ValueNode>
+			</TreeItems>
+		</Expand>
+	</Type>
+
+	<Type Name="::toml::array">
+		<DisplayString>{values}</DisplayString>
+		<Expand>
+			<!-- Modified from std::vector visualizer in VS 2019 stl.natvis -->
+			<IndexListItems>
+				<Size>values._Mypair._Myval2._Mylast - values._Mypair._Myval2._Myfirst</Size>
+				<ValueNode>*values._Mypair._Myval2._Myfirst[$i]</ValueNode>
+			</IndexListItems>
+		</Expand>
+	</Type>
+
+	<Type Name="::toml::abi_parse_noex::parse_result">
+		<DisplayString Condition="!is_err">{*reinterpret_cast&lt;::toml::table*&gt;(&amp;storage)}</DisplayString>
+		<DisplayString Condition="is_err">{*reinterpret_cast&lt;::toml::abi_sf::abi_noex::parse_error*&gt;(&amp;storage)}</DisplayString>
+		<Expand>
+			<Item Name="[table]" Condition="!is_err">*reinterpret_cast&lt;::toml::table*&gt;(&amp;storage)</Item>
+			<Item Name="[error]" Condition="is_err">*reinterpret_cast&lt;::toml::abi_sf::abi_noex::parse_error*&gt;(&amp;storage)</Item>
+			<Item Name="is_err" ExcludeView="simple">is_err</Item>
+		</Expand>
+	</Type>
+
+	<Type Name="::toml::abi_sf::abi_noex::parse_error">
+		<DisplayString>line {source_.begin.line}: {description_,sb}</DisplayString>
+	</Type>
+
+	<Type Name="::toml::abi_lf::abi_noex::parse_error">
+		<DisplayString>line {source_.begin.line}: {description_,sb}</DisplayString>
+	</Type>
+
 </AutoVisualizer>


### PR DESCRIPTION
Hello! I've added debug visualizers for `toml::table`, `toml::array`, and the `parse_result` and `parse_error` types that show up when using the non-exceptions build of the library. These mainly just cut down on visual clutter in the watch window.

Here's what a table looks like with the new visualizers:
![image](https://user-images.githubusercontent.com/1578730/87881450-2d510b80-c9ae-11ea-81e4-253089eb050e.png)

For comparison, this is what it looked like before:
![image](https://user-images.githubusercontent.com/1578730/87881474-48238000-c9ae-11ea-9c93-30081cbdd899.png)

This is what `parse_result` looks like with a successful parse:
![image](https://user-images.githubusercontent.com/1578730/87881485-55d90580-c9ae-11ea-9a5d-847e87b5addd.png)

And this is what it looks like with an error:
![image](https://user-images.githubusercontent.com/1578730/87881500-73a66a80-c9ae-11ea-807e-593b0d11edb1.png)

Hope this is useful to others!