### PR TITLE
Add implicit conversion operators from node to node_view

### DIFF
--- a/include/toml++/toml_node.h
+++ b/include/toml++/toml_node.h
@@ -819,6 +819,12 @@ TOML_NAMESPACE_START
 			{
 				return do_ref<T>(*this);
 			}
+
+			/// \brief	Creates a `node_view` pointing to this node.
+			[[nodiscard]] operator node_view<node>() noexcept;
+
+			/// \brief	Creates a `node_view` pointing to this node (const overload).
+			[[nodiscard]] operator node_view<const node>() const noexcept;
 	};
 }
 TOML_NAMESPACE_END

--- a/include/toml++/toml_node.hpp
+++ b/include/toml++/toml_node.hpp
@@ -87,6 +87,18 @@ TOML_NAMESPACE_START
 	TOML_MEMBER_ATTR(const) const source_region& node::source()				const noexcept { return source_; }
 
 	#undef TOML_MEMBER_ATTR
+
+	TOML_EXTERNAL_LINKAGE
+	node::operator node_view<node>() noexcept
+	{
+		return node_view<node>(this);
+	}
+
+	TOML_EXTERNAL_LINKAGE
+	node::operator node_view<const node>() const noexcept
+	{
+		return node_view<const node>(this);
+	}
 }
 TOML_NAMESPACE_END
 

--- a/include/toml++/toml_node_view.h
+++ b/include/toml++/toml_node_view.h
@@ -63,6 +63,7 @@ TOML_NAMESPACE_START
 			using viewed_type = ViewedType;
 
 		private:
+			friend class TOML_NAMESPACE::node;
 			friend class TOML_NAMESPACE::table;
 			template <typename T> friend class TOML_NAMESPACE::node_view;
 
@@ -88,13 +89,14 @@ TOML_NAMESPACE_START
 			node_view(const node_view&) noexcept = default;
 
 			///// \brief	Copy-assignment operator.
-			TOML_NODISCARD_CTOR
-			node_view& operator= (const node_view&) noexcept = default;
+			node_view& operator= (const node_view&) & noexcept = default;
 
 			///// \brief	Move constructor.
+			TOML_NODISCARD_CTOR
 			node_view(node_view&&) noexcept = default;
 
-			node_view& operator= (node_view&&) noexcept = delete;
+			///// \brief	Move-assignment operator.
+			node_view& operator= (node_view&&) & noexcept = default;
 
 			/// \brief	Returns true if the view references a node.
 			[[nodiscard]] explicit operator bool() const noexcept { return node_ != nullptr; }

--- a/toml.hpp
+++ b/toml.hpp
@@ -2488,6 +2488,9 @@ TOML_NAMESPACE_START
 			{
 				return do_ref<T>(*this);
 			}
+
+			[[nodiscard]] operator node_view<node>() noexcept;
+			[[nodiscard]] operator node_view<const node>() const noexcept;
 	};
 }
 TOML_NAMESPACE_END
@@ -4420,6 +4423,7 @@ TOML_NAMESPACE_START
 			using viewed_type = ViewedType;
 
 		private:
+			friend class TOML_NAMESPACE::node;
 			friend class TOML_NAMESPACE::table;
 			template <typename T> friend class TOML_NAMESPACE::node_view;
 
@@ -4442,12 +4446,12 @@ TOML_NAMESPACE_START
 			TOML_NODISCARD_CTOR
 			node_view(const node_view&) noexcept = default;
 
-			TOML_NODISCARD_CTOR
-			node_view& operator= (const node_view&) noexcept = default;
+			node_view& operator= (const node_view&) & noexcept = default;
 
+			TOML_NODISCARD_CTOR
 			node_view(node_view&&) noexcept = default;
 
-			node_view& operator= (node_view&&) noexcept = delete;
+			node_view& operator= (node_view&&) & noexcept = default;
 			[[nodiscard]] explicit operator bool() const noexcept { return node_ != nullptr; }
 			[[nodiscard]] viewed_type* node() const noexcept { return node_; }
 
@@ -7507,6 +7511,18 @@ TOML_NAMESPACE_START
 	TOML_MEMBER_ATTR(const) const source_region& node::source()				const noexcept { return source_; }
 
 	#undef TOML_MEMBER_ATTR
+
+	TOML_EXTERNAL_LINKAGE
+	node::operator node_view<node>() noexcept
+	{
+		return node_view<node>(this);
+	}
+
+	TOML_EXTERNAL_LINKAGE
+	node::operator node_view<const node>() const noexcept
+	{
+		return node_view<const node>(this);
+	}
 }
 TOML_NAMESPACE_END
 


### PR DESCRIPTION
Hello! I've made a couple of changes to loosen restrictions on the use of `node_view`. Primarily, I added implicit conversion operators from `node` to `node_view` (const and mutable variants). Also, I re-enabled the move assignment operator on `node_view`.

This was motivated by me running into trouble while trying to write code to traverse a table procedurally. Basically, I wanted to do something like this:
```cpp
toml::node_view<const toml::node> child = myTable;
for (auto key : keyPath)
{
    child = child[key];
}
```
where I'm descending into a table using a list of keys in `keyPath`.

In opting to do this by adding implicit conversion operators (as opposed to e.g. adding a constructor on `node_view`, or explicit conversion functions), I was guided by `std::string`, which similarly has an implicit conversion to `std::string_view`. String views are always const, but here I wanted to allow either const or non-const `node_views` so I added both.

I also found that statements like `child = child[key]` above want the move assignment operator, which was disabled. I didn't see any reason for that to be disabled, especially considering that copy assignment is enabled, so I turned it back on.

I'm open to discussion on this if there are other ways you'd prefer to accomplish this, though. 🙂

**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK.
--->
- [x] I've read [CONTRIBUTING.md]
- [ ] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation (_didn't do this as I don't have Doxygen installed_)
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [x] Visual Studio 2019
- [x] I've forever enshrined myself in glory by adding myself to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md