### PR TITLE
Rename Windows.h to windows.h for mingw-w64

### DIFF
--- a/examples/utf8_console.h
+++ b/examples/utf8_console.h
@@ -5,7 +5,7 @@
 
 #include <iostream>
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 inline void init_utf8_console() noexcept

--- a/include/toml++/toml_default_formatter.hpp
+++ b/include/toml++/toml_default_formatter.hpp
@@ -208,7 +208,7 @@ TOML_NAMESPACE_END
 #if TOML_WINDOWS_COMPAT
 
 TOML_DISABLE_WARNINGS
-#include <Windows.h> // fuckkkk :(
+#include <windows.h> // fuckkkk :(
 TOML_ENABLE_WARNINGS
 
 TOML_IMPL_NAMESPACE_START

--- a/tests/manipulating_values.cpp
+++ b/tests/manipulating_values.cpp
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 TOML_DISABLE_WARNINGS
-#include <Windows.h>
+#include <windows.h>
 TOML_ENABLE_WARNINGS
 #endif
 

--- a/tests/windows_compat.cpp
+++ b/tests/windows_compat.cpp
@@ -8,7 +8,7 @@
 #if TOML_WINDOWS_COMPAT
 
 TOML_DISABLE_WARNINGS
-#include <Windows.h>
+#include <windows.h>
 TOML_ENABLE_WARNINGS
 
 TEST_CASE("windows compat")

--- a/toml.hpp
+++ b/toml.hpp
@@ -8387,7 +8387,7 @@ TOML_NAMESPACE_END
 #if TOML_WINDOWS_COMPAT
 
 TOML_DISABLE_WARNINGS
-#include <Windows.h> // fuckkkk :(
+#include <windows.h> // fuckkkk :(
 TOML_ENABLE_WARNINGS
 
 TOML_IMPL_NAMESPACE_START


### PR DESCRIPTION
Use lower case header file names for compilation with mingw-w64.
