### PR TITLE
fix warnings

### DIFF
--- a/include/toml++/toml_array.h
+++ b/include/toml++/toml_array.h
@@ -1036,7 +1036,7 @@ TOML_NAMESPACE_START
 			/// \returns An rvalue reference to the array.
 			array&& flatten() &&
 			{
-				return static_cast<toml::array&&>(static_cast<toml::array&>(*this).flatten());
+				return std::move(this->flatten());
 			}
 
 			/// \brief	Prints the array out to a stream as formatted TOML.

--- a/include/toml++/toml_default_formatter.hpp
+++ b/include/toml++/toml_default_formatter.hpp
@@ -53,10 +53,7 @@ TOML_IMPL_NAMESPACE_START
 				for (auto c : str)
 				{
 					if TOML_UNLIKELY(c >= '\x00' && c <= '\x1F')
-					{
-						const auto& sv = low_character_escape_table[c];
-						s.append(reinterpret_cast<const char*>(sv.data()), sv.length());
-					}
+						s.append(low_character_escape_table[c]);
 					else if TOML_UNLIKELY(c == '\x7F')
 						s.append("\\u007F"sv);
 					else if TOML_UNLIKELY(c == '"')
@@ -141,7 +138,7 @@ TOML_IMPL_NAMESPACE_START
 					weight += 1;
 					v *= -1.0;
 				}
-				return weight + static_cast<size_t>(log10(static_cast<double>(v))) + 1_sz;
+				return weight + static_cast<size_t>(log10(v)) + 1_sz;
 				break;
 			}
 

--- a/toml.hpp
+++ b/toml.hpp
@@ -3963,7 +3963,7 @@ TOML_NAMESPACE_START
 			array& flatten() &;
 			array&& flatten() &&
 			{
-				return static_cast<toml::array&&>(static_cast<toml::array&>(*this).flatten());
+				return std::move(this->flatten());
 			}
 
 			template <typename Char>
@@ -8368,10 +8368,7 @@ TOML_IMPL_NAMESPACE_START
 				for (auto c : str)
 				{
 					if TOML_UNLIKELY(c >= '\x00' && c <= '\x1F')
-					{
-						const auto& sv = low_character_escape_table[c];
-						s.append(reinterpret_cast<const char*>(sv.data()), sv.length());
-					}
+						s.append(low_character_escape_table[c]);
 					else if TOML_UNLIKELY(c == '\x7F')
 						s.append("\\u007F"sv);
 					else if TOML_UNLIKELY(c == '"')
@@ -8456,7 +8453,7 @@ TOML_IMPL_NAMESPACE_START
 					weight += 1;
 					v *= -1.0;
 				}
-				return weight + static_cast<size_t>(log10(static_cast<double>(v))) + 1_sz;
+				return weight + static_cast<size_t>(log10(v)) + 1_sz;
 				break;
 			}
 


### PR DESCRIPTION
MinGW/GCC 10 report with -Wuseless-cast

<!--
    Please replace the HTML comments below with the requested information.
    Or leave them there and put your answers above/below them; you do you!

    Thanks for contributing!
-->



**What does this change do?**
<!--
    Changes all Foos to Bars.
--->
Fix three Warnings of casting `T` to `T´.


**Is it related to an exisiting bug report or feature request?**
<!--
    Fixes #69.
--->
No


**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK.
--->
- [X] I've read [CONTRIBUTING.md]
- [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [X] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [X] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [X] GCC 7 or higher (*)
    - [ ] Visual Studio 2019
- [ ] I've given myself mad props by adding my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

(*): MinGW/GCC 10: I needed two changes:

1. I've had to comment out `add_project_arguments(has_exceptions ? '-D_HAS_EXCEPTIONS=1' : '-D_HAS_EXCEPTIONS=0', language : 'cpp')` otherwise it gets defined twice and results in an error:
```
FAILED: meson-out/cpp17_noexcept.exe.p/conformance_burntsushi_invalid.cpp.obj
"c++" "-Imeson-out/cpp17_noexcept.exe.p" "-Itests" "-I../tests" "-I../include" "-I../extern" "-fdiagnostics-color=always" "-pipe" "-D_FILE_OFFSET_BITS=64" "-Wall" "-Winvalid-pch" "-Wnon-virtual-dtor" "-Wextra" "-Wpedantic" "-Werror" "-std=c++17" "-fno-exceptions" "-g" "-march=native" "-fmax-errors=5" "-Wno-init-list-lifetime" "-Wcast-align" "-Wcast-qual" "-Wctor-dtor-privacy" "-Wdisabled-optimization" "-Wextra" "-Wfloat-equal" "-Wimport" "-Winit-self" "-Wlogical-op" "-Wmissing-declarations" "-Wmissing-field-initializers" "-Wmissing-format-attribute" "-Wmissing-include-dirs" "-Wmissing-noreturn" "-Wnoexcept" "-Wold-style-cast" "-Woverloaded-virtual" "-Wpacked" "-Wpadded" "-Wpedantic" "-Wpointer-arith" "-Wredundant-decls" "-Wshadow" "-Wsign-conversion" "-Wsign-promo" "-Wstack-protector" "-Wstrict-null-sentinel" "-Wswitch-default" "-Wswitch-enum" "-Wundef" "-Wunreachable-code" "-Wunused" "-Wunused-parameter" "-Wvariadic-macros" "-Wwrite-strings" "-Wmissing-noreturn" "-Wsuggest-attribute=const" "-Wsuggest-attribute=pure" "-D_ITERATOR_DEBUG_LEVEL=0" "-D_WINSOCK_DEPRECATED_NO_WARNINGS" "-D_SCL_SECURE_NO_WARNINGS" "-D_CRT_SECURE_NO_WARNINGS" "-D_HAS_EXCEPTIONS=1" "-fext-numeric-literals" "-DSHOULD_HAVE_EXCEPTIONS=0" "-D_HAS_EXCEPTIONS=0" "-DSHOULD_HAVE_INT128=1" "-DSHOULD_HAVE_FLOAT128=1" "-DTOML_UNRELEASED_FEATURES=0" "-DUSE_SINGLE_HEADER=1" -MD -MQ meson-out/cpp17_noexcept.exe.p/conformance_burntsushi_invalid.cpp.obj -MF "meson-out/cpp17_noexcept.exe.p/conformance_burntsushi_invalid.cpp.obj.d" -o meson-out/cpp17_noexcept.exe.p/conformance_burntsushi_invalid.cpp.obj "-c" ../tests/conformance_burntsushi_invalid.cpp
<command-line>: error: "_HAS_EXCEPTIONS" redefined [-Werror]
<command-line>: note: this is the location of the previous definition
cc1plus.exe: all warnings being treated as errors
```
2. Deactivate the `THIS_IS_AN_EVIL_MACRO` because it modified `std::min`, `std::numeric_limits::min`, and the `max`counterparts. I don't know if this test is designed to work with MinGW, or just MSVC.

3. Locales seem to work differently (or not at all?) with MinGW.

**Anything else?**
<!--
    According to all known laws of aviation, there is no way a bee should be able to fly.
    Its wings are too small to get its fat little body off the ground.
    The bee, of course, flies anyway, because bees don't care what humans think is impossible.
--->



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md