### PR TITLE
Make iterators real iterators

### DIFF
--- a/include/toml++/toml_array.h
+++ b/include/toml++/toml_array.h
@@ -38,6 +38,7 @@ TOML_IMPL_NAMESPACE_START
 			using reference = value_type&;
 			using pointer = value_type*;
 			using difference_type = ptrdiff_t;
+			using iterator_category = typename std::iterator_traits<raw_iterator>::iterator_category;
 
 			array_iterator() noexcept = default;
 			array_iterator(const array_iterator&) noexcept = default;

--- a/include/toml++/toml_common.h
+++ b/include/toml++/toml_common.h
@@ -16,6 +16,7 @@ TOML_DISABLE_WARNINGS
 #include <cstring>
 #include <cfloat>
 #include <climits>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <string_view>

--- a/include/toml++/toml_table.h
+++ b/include/toml++/toml_table.h
@@ -75,6 +75,8 @@ TOML_IMPL_NAMESPACE_START
 			using value_type = table_proxy_pair<IsConst>;
 			using reference = value_type&;
 			using pointer = value_type*;
+			using difference_type = typename std::iterator_traits<raw_iterator>::difference_type;
+			using iterator_category = typename std::iterator_traits<raw_iterator>::iterator_category;
 
 			table_iterator& operator++() noexcept // ++pre
 			{

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,6 +21,7 @@ test_sources = [
 	'manipulating_values.cpp',
 	'unicode.cpp',
 	'user_feedback.cpp',
+	'using_iterators.cpp',
 	'windows_compat.cpp'
 ]
 

--- a/tests/using_iterators.cpp
+++ b/tests/using_iterators.cpp
@@ -1,0 +1,55 @@
+#include "tests.h"
+
+TOML_DISABLE_WARNINGS
+#include <algorithm>
+TOML_ENABLE_WARNINGS
+
+TEST_CASE("Using std::distance, std::count_if, etc. with Iterators")
+{
+	constexpr auto data = R"(array=[1,"Foo",true]
+string="Bar"
+number=5)"sv;
+	parsing_should_succeed(FILE_LINE_ARGS, data, [](auto&& table)
+	{
+		const auto table_begin = table.begin();
+		const auto table_end = table.end();
+
+		auto count_table_lambda = [table_begin, table_end](node_type type) noexcept
+		{
+			return std::count_if(table_begin, table_end, [type](const auto& pair) noexcept
+			{
+				return pair.second.type() == type;
+			});
+		};
+
+		CHECK(std::distance(table_begin, table_end) == 3);
+		CHECK(count_table_lambda(node_type::table) == 0);
+		CHECK(count_table_lambda(node_type::integer) == 1);
+		CHECK(count_table_lambda(node_type::string) == 1);
+		CHECK(std::next(table_begin, 3) == table_end);
+
+		const auto array_iter = std::find_if(table_begin, table_end, [](const auto& pair) noexcept
+		{
+			return pair.second.is_array();
+		});
+
+		REQUIRE(array_iter != table_end);
+		const auto& array = array_iter->second.as_array();
+		const auto array_begin = array->begin();
+		const auto array_end = array->end();
+
+		auto count_array_lambda = [array_begin, array_end](node_type type) noexcept
+		{
+			return std::count_if(array_begin, array_end, [type](const auto& node) noexcept
+			{
+				return node.type() == type;
+			});
+		};
+
+		CHECK(std::distance(array_begin, array_end) == 3);
+		CHECK(count_array_lambda(node_type::table) == 0);
+		CHECK(count_array_lambda(node_type::integer) == 1);
+		CHECK(count_array_lambda(node_type::string) == 1);
+		CHECK(std::next(array_begin, 2) != array_end);
+	});
+}

--- a/toml.hpp
+++ b/toml.hpp
@@ -613,6 +613,7 @@ TOML_DISABLE_WARNINGS
 #include <cstring>
 #include <cfloat>
 #include <climits>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <string_view>
@@ -3433,6 +3434,7 @@ TOML_IMPL_NAMESPACE_START
 			using reference = value_type&;
 			using pointer = value_type*;
 			using difference_type = ptrdiff_t;
+			using iterator_category = typename std::iterator_traits<raw_iterator>::iterator_category;
 
 			array_iterator() noexcept = default;
 			array_iterator(const array_iterator&) noexcept = default;
@@ -4047,6 +4049,8 @@ TOML_IMPL_NAMESPACE_START
 			using value_type = table_proxy_pair<IsConst>;
 			using reference = value_type&;
 			using pointer = value_type*;
+			using difference_type = typename std::iterator_traits<raw_iterator>::difference_type;
+			using iterator_category = typename std::iterator_traits<raw_iterator>::iterator_category;
 
 			table_iterator& operator++() noexcept // ++pre
 			{


### PR DESCRIPTION
They were missing the iterator_category and thus could not be used with
some standard algorithms.

<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->



**What does this change do?**
<!--
    Changes all Foos to Bars.
--->
Making table_iterator and array_iterator usable with standard algorithms and iterator functions.


**Is it related to an exisiting bug report or feature request?**
<!--
    Fixes #69.
--->



**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [X] I've read [CONTRIBUTING.md]
- [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [X] I've added new test cases to verify my change
- [X] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [X] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md