### PR TITLE
Don't insert emty table to empty table arrays

### DIFF
--- a/tests/parsing_tables.cpp
+++ b/tests/parsing_tables.cpp
@@ -439,3 +439,31 @@ fruit = []
 )"sv);
 
 }
+
+TEST_CASE("parsing - empty arrays-of-tables")
+{
+	parsing_should_succeed(
+		FILE_LINE_ARGS,
+		R"(
+[[fruit.variety]]
+)"sv,
+		[](table&& tbl)
+		{
+			REQUIRE(tbl["fruit"].as<table>());
+			REQUIRE(tbl["fruit"]["variety"].as<array>());
+			CHECK(tbl["fruit"]["variety"].as<array>()->size() == 0u);
+		}
+	);
+
+		parsing_should_succeed(
+		FILE_LINE_ARGS,
+		R"(
+[[fruit]]
+)"sv,
+		[](table&& tbl)
+		{
+			REQUIRE(tbl["fruit"].as<array>());
+			CHECK(tbl["fruit"].as<array>()->size() == 0u);
+		}
+	);
+}

--- a/toml.hpp
+++ b/toml.hpp
@@ -11320,10 +11320,7 @@ TOML_IMPL_NAMESPACE_START
 							).first->second->ref_cast<array>();
 						table_arrays.push_back(tab_arr);
 						tab_arr->source_ = { header_begin_pos, header_end_pos, reader.source_path() };
-
-						tab_arr->elements.emplace_back(new toml::table{});
-						tab_arr->elements.back()->source_ = { header_begin_pos, header_end_pos, reader.source_path() };
-						return &tab_arr->elements.back()->ref_cast<table>();
+						return parent;
 					}
 
 					//otherwise we're just making a table
@@ -11440,7 +11437,7 @@ TOML_IMPL_NAMESPACE_START
 				assert_not_eof();
 				push_parse_scope("root table"sv);
 				table* current_table = &root;
-
+				size_t old_size_tables_array = table_arrays.size();
 				do
 				{
 					return_if_error();
@@ -11455,13 +11452,21 @@ TOML_IMPL_NAMESPACE_START
 					// [tables]
 					// [[table array]]
 					if (*cp == U'[')
+					{
+						static_cast<void>(insert_table_to_table_arrays_if_need(old_size_tables_array));
 						current_table = parse_table_header();
+					}
 
 					// bare_keys
 					// dotted.keys
 					// "quoted keys"
 					else if (is_bare_key_character(*cp) || is_string_delimiter(*cp))
 					{
+						if (auto table = insert_table_to_table_arrays_if_need(old_size_tables_array); table)
+						{
+							current_table = table;
+						}
+
 						push_parse_scope("key-value pair"sv);
 
 						parse_key_value_pair_and_insert(current_table);
@@ -11521,6 +11526,18 @@ TOML_IMPL_NAMESPACE_START
 					}
 					nde.source_.end = end;
 				}
+			}
+
+			[[nodiscard]]
+			toml::table* insert_table_to_table_arrays_if_need(size_t &old) noexcept
+			{
+				if (old < table_arrays.size())
+				{
+					old = table_arrays.size();
+					return table_arrays.back()->insert(table_arrays.back()->end(), toml::table{})->as_table();
+				}
+
+				return nullptr;
 			}
 
 		public:


### PR DESCRIPTION
Doesn't create empty table in empty arrays of tables

- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [x] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [x] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [x] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)