### PR TITLE
add cmake files to build and install header only library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.13...3.19)
+
+project(tomlplusplus LANGUAGES CXX VERSION 2.3.1)
+
+# Determine if this project is built as a subproject (using
+# add_subdirectory) or if it is the master project.
+set(MASTER_PROJECT OFF)
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(MASTER_PROJECT ON)
+    message(STATUS "CMake version: ${CMAKE_VERSION}")
+endif()
+
+
+add_library(tomlplusplus INTERFACE)
+add_library(tomlplusplus::tomlplusplus ALIAS tomlplusplus)
+target_compile_features(tomlplusplus INTERFACE cxx_std_17)
+target_include_directories(tomlplusplus INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+
+option(TOMLPP_BUILD_EXAMPLES "Build examples." ${MASTER_PROJECT})
+if(TOMLPP_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+
+option(TOMLPP_INSTALL "Generate the install target" ${MASTER_PROJECT})
+if(TOMLPP_INSTALL)
+    include(CMakePackageConfigHelpers)
+    include(GNUInstallDirs)
+    install(TARGETS tomlplusplus EXPORT ${PROJECT_NAME}Targets)
+
+    install(DIRECTORY include/toml++ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+    write_basic_package_version_file(
+        ${PROJECT_NAME}ConfigVersion.cmake
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install(
+        FILES cmake/tomlplusplusConfig.cmake # ---------->
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
+
+    install(
+        EXPORT ${PROJECT_NAME}Targets
+        NAMESPACE ${PROJECT_NAME}::
+        FILE ${PROJECT_NAME}Targets.cmake   # <----------
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+    )
+endif()

--- a/cmake/tomlplusplusConfig.cmake
+++ b/cmake/tomlplusplusConfig.cmake
@@ -1,0 +1,1 @@
+include(${CMAKE_CURRENT_LIST_DIR}/tomlplusplusTargets.cmake)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,11 +2,12 @@ cmake_minimum_required(VERSION 3.13...3.19)
 
 project(Examples LANGUAGES CXX)
 
-find_package(tomlplusplus REQUIRED)
+if(NOT TARGET tomlplusplus::tomlplusplus)
+    find_package(tomlplusplus REQUIRED)
+endif()
 
 add_executable(toml_to_json_transcoder toml_to_json_transcoder.cpp)
 target_link_libraries(toml_to_json_transcoder PRIVATE tomlplusplus::tomlplusplus)
-#XXX target_compile_features(toml_to_json_transcoder PRIVATE cxx_std_17)
 
 enable_testing()
 add_test(NAME toml_to_json_transcoder

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.13...3.19)
+
+project(Examples LANGUAGES CXX)
+
+find_package(tomlplusplus REQUIRED)
+
+add_executable(toml_to_json_transcoder toml_to_json_transcoder.cpp)
+target_link_libraries(toml_to_json_transcoder PRIVATE tomlplusplus::tomlplusplus)
+#XXX target_compile_features(toml_to_json_transcoder PRIVATE cxx_std_17)
+
+enable_testing()
+add_test(NAME toml_to_json_transcoder
+    COMMAND toml_to_json_transcoder ${CMAKE_CURRENT_LIST_DIR}/example.toml
+)


### PR DESCRIPTION
add simple cmake files to support cmake usage as subproject

optional support install and import of cmake config package files

**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [x] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [x] Clang 6 or higher
    - [x] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md