### PR TITLE
Introduce a heuristic to print floating point numbers more coincely

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 - **[@traversaro](https://github.com/traversaro)** - Added vcpkg support and reported a bunch of bugs
 - **[@ximion](https://github.com/ximion)** - Added support for installation with meson
 - **[@whiterabbit963](https://github.com/whiterabbit963)** - Fixed a bug with value_or conversions
+- **[@vaartis](https://github.com/vaartis)** - Introduced a heuristic to print some floating point numbers more coincely.
 
 <br>
 


### PR DESCRIPTION
**What does this change do?**

Introduces a heuristic that, for floating pointer numbers that have <=3 positions after the floating point, prints them with just those, and otherwise it prints them with the usual `std::numeric_limits<T>::digits10 + 1` precision.

**Is it related to an exisiting bug report or feature request?**

Continuation of #88 


**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [x] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md