### PR TITLE
Bypass including Windows.h (MultiByteToWideChar/WideCharToMultiByte)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 - **[@traversaro](https://github.com/traversaro)** - Added vcpkg support and reported a bunch of bugs
 - **[@ximion](https://github.com/ximion)** - Added support for installation with meson
 - **[@whiterabbit963](https://github.com/whiterabbit963)** - Fixed a bug with value_or conversions
-
+- **[@beastle9end](https://github.com/beastle9end)** - Made Windows.h include bypass
 <br>
 
 # Contact

--- a/include/toml++/toml_default_formatter.hpp
+++ b/include/toml++/toml_default_formatter.hpp
@@ -204,9 +204,16 @@ TOML_NAMESPACE_END;
 // implementations of windows wide string nonsense
 #if TOML_WINDOWS_COMPAT
 
-TOML_DISABLE_WARNINGS;
-#include <windows.h> // fuckkkk :(
-TOML_ENABLE_WARNINGS;
+namespace winapi
+{
+    extern "C"
+    {
+        int __stdcall WideCharToMultiByte(unsigned int CodePage, unsigned long dwFlags, const wchar_t* lpWideCharStr, int cchWideChar,
+                                          const char* lpMultiByteStr, int cbMultiByte, const char* lpDefaultChar, int* lpUsedDefaultChar);
+        int __stdcall MultiByteToWideChar(unsigned int CodePage, unsigned long dwFlags, const char* lpMultiByteStr, int cbMultiByte,
+                                      const wchar_t* lpWideCharStr, int cchWideChar);
+    }
+}
 
 TOML_IMPL_NAMESPACE_START
 {
@@ -218,13 +225,13 @@ TOML_IMPL_NAMESPACE_START
 			return {};
 
 		std::string s;
-		const auto len = WideCharToMultiByte(
+		const auto len = winapi::WideCharToMultiByte(
 			65001, 0, str.data(), static_cast<int>(str.length()), nullptr, 0, nullptr, nullptr
 		);
 		if (len)
 		{
 			s.resize(static_cast<size_t>(len));
-			WideCharToMultiByte(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len, nullptr, nullptr);
+            winapi::WideCharToMultiByte(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len, nullptr, nullptr);
 		}
 		return s;
 	}
@@ -237,11 +244,11 @@ TOML_IMPL_NAMESPACE_START
 			return {};
 
 		std::wstring s;
-		const auto len = MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), nullptr, 0);
+		const auto len = winapi::MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), nullptr, 0);
 		if (len)
 		{
 			s.resize(static_cast<size_t>(len));
-			MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len);
+            winapi::MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len);
 		}
 		return s;
 	}

--- a/toml.hpp
+++ b/toml.hpp
@@ -11963,9 +11963,16 @@ TOML_NAMESPACE_END;
 // implementations of windows wide string nonsense
 #if TOML_WINDOWS_COMPAT
 
-TOML_DISABLE_WARNINGS;
-#include <windows.h> // fuckkkk :(
-TOML_ENABLE_WARNINGS;
+namespace winapi
+{
+    extern "C"
+    {
+        int __stdcall WideCharToMultiByte(unsigned int CodePage, unsigned long dwFlags, const wchar_t* lpWideCharStr, int cchWideChar,
+                                          const char* lpMultiByteStr, int cbMultiByte, const char* lpDefaultChar, int* lpUsedDefaultChar);
+        int __stdcall MultiByteToWideChar(unsigned int CodePage, unsigned long dwFlags, const char* lpMultiByteStr, int cbMultiByte,
+                                      const wchar_t* lpWideCharStr, int cchWideChar);
+    }
+}
 
 TOML_IMPL_NAMESPACE_START
 {
@@ -11977,13 +11984,13 @@ TOML_IMPL_NAMESPACE_START
 			return {};
 
 		std::string s;
-		const auto len = WideCharToMultiByte(
+		const auto len = winapi::WideCharToMultiByte(
 			65001, 0, str.data(), static_cast<int>(str.length()), nullptr, 0, nullptr, nullptr
 		);
 		if (len)
 		{
 			s.resize(static_cast<size_t>(len));
-			WideCharToMultiByte(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len, nullptr, nullptr);
+            winapi::WideCharToMultiByte(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len, nullptr, nullptr);
 		}
 		return s;
 	}
@@ -11996,11 +12003,11 @@ TOML_IMPL_NAMESPACE_START
 			return {};
 
 		std::wstring s;
-		const auto len = MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), nullptr, 0);
+		const auto len = winapi::MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), nullptr, 0);
 		if (len)
 		{
 			s.resize(static_cast<size_t>(len));
-			MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len);
+            winapi::MultiByteToWideChar(65001, 0, str.data(), static_cast<int>(str.length()), s.data(), len);
 		}
 		return s;
 	}


### PR DESCRIPTION
**What does this change do?**
It bypasses including Windows.h by defining MultiByteToWideChar and WideCharToMultiByte inside an internal winapi namespace.

**Is it related to an exisiting bug report or feature request?**
No, just had a problem with it in my own project, but was marked with a comment inside the code

**Pre-merge checklist**
- [x] I've read [CONTRIBUTING.md]
- [ ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [x] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md