### PR TITLE
Restore CMake package config used by Meson

### DIFF
--- a/cmake/tomlplusplus.cmake.in
+++ b/cmake/tomlplusplus.cmake.in
@@ -1,0 +1,14 @@
+@PACKAGE_INIT@
+
+# If tomlplusplus::tomlplusplus target is not defined it will be included
+if(NOT TARGET tomlplusplus::tomlplusplus)
+
+  # Import tomlplusplus interface library
+  add_library(tomlplusplus::tomlplusplus INTERFACE IMPORTED)
+  set_target_properties(tomlplusplus::tomlplusplus PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include")
+
+  # Require C++17
+  target_compile_features(tomlplusplus::tomlplusplus INTERFACE cxx_std_17)
+
+endif()


### PR DESCRIPTION
**What does this change do?**
Restores the config file used by Meson that I unknowingly assumed to be unnecessary.

**Is it related to an exisiting bug report or feature request?**
Fixes https://github.com/marzer/tomlplusplus/issues/104

**Pre-merge checklist**
- [x] I've read [CONTRIBUTING.md]
- [ ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md