### PR TITLE
Add natvis file to cmake install rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 - **[@prince-chrismc](https://github.com/prince-chrismc)** - Added toml++ to ConanCenter, and fixed some typos
 - **[@rbrugo](https://github.com/rbrugo)** - Helped design a new feature
 - **[@Reedbeta](https://github.com/Reedbeta)** - Fixed a bug and added additional Visual Studio debugger native visualizers
+- **[@Ryan-rsm-McKenzie](https://github.com/Ryan-rsm-McKenzie)** - Add natvis file to cmake install script
 - **[@shdnx](https://github.com/shdnx)** - Fixed a bug on GCC 8.2.0 and some meson config issues
 - **[@sobczyk](https://github.com/sobczyk)** - Reported some bugs
 - **[@sneves](https://github.com/sneves)** - Helped fix a number of parser bugs

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -2,6 +2,12 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 install(
+    FILES "${PROJECT_SOURCE_DIR}/toml++.natvis"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/tomlplusplus"
+    COMPONENT tomlplusplus_Development
+)
+
+install(
     DIRECTORY "${PROJECT_SOURCE_DIR}/include/"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     COMPONENT tomlplusplus_Development


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->



**What does this change do?**
<!--
    Changes all Foos to Bars.
--->
This ensures the natvis file is installed in addition to the header files.



**Is it related to an exisiting bug report or feature request?**
<!--
    Fixes #69.
--->
Nope.


**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)


Ideally the meson script would also install the natvis file, but I don't anything about meson.
For reference, (by default) this installs it into `<some-install-path>/share/tomlplusplus/toml++.natvis`.

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md