### PR TITLE
build(meson): do not install if used as subproj

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -496,10 +496,12 @@ if build_examples
 	subdir('examples')
 endif
 
-install_subdir('include/toml++',
-	strip_directory: true,
-	install_dir: 'include/toml++'
-)
+if not is_subproject
+	install_subdir('include/toml++',
+		strip_directory: true,
+		install_dir: 'include/toml++'
+	)
+endif
 
 #######################################################################################################################
 # dependencies, cmake etc.
@@ -510,13 +512,14 @@ tomlplusplus_dep = declare_dependency(
 	version : meson.project_version(),
 )
 
-pkgc = import('pkgconfig')
-pkgc.generate(
-	name: meson.project_name(),
-	version: meson.project_version(),
-	description: 'Header-only TOML config file parser and serializer for C++',
-	install_dir: join_paths(get_option('datadir'), 'pkgconfig'),
-)
+if not is_subproject
+	import('pkgconfig').generate(
+		name: meson.project_name(),
+		version: meson.project_version(),
+		description: 'Header-only TOML config file parser and serializer for C++',
+		install_dir: join_paths(get_option('datadir'), 'pkgconfig'),
+	)
+endif
 
 # cmake
 if get_option('generate_cmake_config') and not is_subproject


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->



**What does this change do?**
<!--
    Changes all Foos to Bars.
--->
Prevents the headers and pkg-config file from being installed when the library is used as a subproject. 
Another possible approach would be to add a new option for disabling installation, but I don't see how installing a header-only library with the final executable would be useful (headers are only useful for development).


**Is it related to an exisiting bug report or feature request?**
<!--
    Fixes #69.
--->
Nope, I directly created a PR instead of creating an issue and fixing it myself. 


**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change _(not necessary)_
- [ ] I've regenerated toml.hpp _(not necessary)_
- [ ] I've updated any affected documentation _(not necessary)_
- [ ] I've rebuilt and run the tests with at least one of: _(not necessary)_
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md) (small change, I don't deserve it)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md