### PR TITLE
build(meson): use `override_dependency` if supported

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -508,6 +508,10 @@ tomlplusplus_dep = declare_dependency(
 	version: meson.project_version(),
 )
 
+if meson.version().version_compare('>=0.54.0')
+	meson.override_dependency('tomlplusplus', tomlplusplus_dep)
+endif
+
 if not is_subproject
 	import('pkgconfig').generate(
 		name: meson.project_name(),


### PR DESCRIPTION
**What does this change do?**
This improves user experience when using toml++ as a Meson subproject.

With this change users will be able to simply call `dependency('tomlplusplus')` and have Meson automatically resolve the dependency from the subproject if it is not found on the system.

Without this, users always have to explicitly call `dependency('tomlplusplus', fallback: ['tomlplusplus', 'tomlplusplus_dep'])`

A lot of saved keystrokes :)

**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md