### PR TITLE
Update docs with information about meson wrap

### DIFF
--- a/docs/pages/main_page.dox
+++ b/docs/pages/main_page.dox
@@ -444,7 +444,12 @@
 
 
  \subsection mainpage-adding-lib-meson Meson
- The library supports being added as a subproject in the meson build system.
+ You can install the wrap with:
+ \bash
+ meson wrap install tomlplusplus
+ \ebash
+ After that, you can use it like a regular dependency: `tomlplusplus_dep = dependency('tomlplusplus')`.
+ You can also add it as a subproject directly.
 
 
 


### PR DESCRIPTION
I've added the library as a Meson wrap ([see PR](https://github.com/mesonbuild/wrapdb/pull/250)),
and updated the section about installing the library.

**What does this change do?**
Updates the docs with information about the wrap. (I hope I got the formatting correct!)



**Is it related to an exisiting bug report or feature request?**
No



**Pre-merge checklist**
- [x] I've read [CONTRIBUTING.md]
- [ ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [x] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md