### PR TITLE
build(meson): install CMake Config files to datadir

### DIFF
--- a/cmake/tomlplusplus.cmake.in
+++ b/cmake/tomlplusplus.cmake.in
@@ -6,7 +6,7 @@ if(NOT TARGET tomlplusplus::tomlplusplus)
   # Import tomlplusplus interface library
   add_library(tomlplusplus::tomlplusplus INTERFACE IMPORTED)
   set_target_properties(tomlplusplus::tomlplusplus PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/include")
+    INTERFACE_INCLUDE_DIRECTORIES "${PACKAGE_PREFIX_DIR}/@includedir@")
 
   # Require C++17
   target_compile_features(tomlplusplus::tomlplusplus INTERFACE cxx_std_17)

--- a/cmake/tomlplusplusConfigVersion.cmake.in
+++ b/cmake/tomlplusplusConfigVersion.cmake.in
@@ -1,0 +1,48 @@
+# This is a basic version file for the Config-mode of find_package().
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version.
+# The variable CVF_VERSION must be set before calling configure_file().
+
+set(PACKAGE_VERSION "@version@")
+
+if (PACKAGE_FIND_VERSION_RANGE)
+  # Package version must be in the requested version range
+  if ((PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      OR ((PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+        OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND PACKAGE_VERSION VERSION_GREATER_EQUAL PACKAGE_FIND_VERSION_MAX)))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
+else()
+  if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()
+
+
+# if the installed project requested no architecture check, don't perform the check
+if("True")
+  return()
+endif()
+
+# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "" OR "8" STREQUAL "")
+  return()
+endif()
+
+# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+if(NOT CMAKE_SIZEOF_VOID_P STREQUAL "8")
+  math(EXPR installedBits "8 * 8")
+  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()

--- a/meson.build
+++ b/meson.build
@@ -512,17 +512,13 @@ endif
 # dependencies, cmake etc.
 #######################################################################################################################
 
-tomlplusplus_dep = declare_dependency(
-	include_directories: include_directories('include'),
-	version: meson.project_version(),
-)
+tomlplusplus_dep = declare_dependency(include_directories: 'include')
 
-meson.override_dependency('tomlplusplus', tomlplusplus_dep)
+meson.override_dependency(meson.project_name(), tomlplusplus_dep)
 
 if not is_subproject
 	import('pkgconfig').generate(
 		name: meson.project_name(),
-		version: meson.project_version(),
 		description: 'Header-only TOML config file parser and serializer for C++',
 		install_dir: get_option('datadir')/'pkgconfig',
 	)
@@ -531,17 +527,27 @@ endif
 # cmake
 if get_option('generate_cmake_config') and not is_subproject
 	cmake = import('cmake')
-	cmake.write_basic_package_version_file(
-		name: meson.project_name(),
-		version: meson.project_version(),
-		install_dir: 'lib'/'cmake'/meson.project_name(),
+	# Can't use until Meson 0.62.0, see https://github.com/mesonbuild/meson/pull/9916
+	# and https://github.com/marzer/tomlplusplus/issues/140
+	#cmake.write_basic_package_version_file(
+	#	name: meson.project_name(),
+	#	version: meson.project_version(),
+	#	install_dir: get_option('datadir')/'cmake'/meson.project_name(),
+	#	arch_independent: true
+	#)
+	# In the meantime, install a pre-generated Package Version file
+	configure_file(
+		configuration: {'version': meson.project_version()},
+		input: 'cmake'/'tomlplusplusConfigVersion.cmake.in',
+		output: 'tomlplusplusConfigVersion.cmake',
+		install: true,
+		install_dir: get_option('datadir')/'cmake'/meson.project_name()
 	)
 
-	cmake_conf = configuration_data()
 	cmake.configure_package_config_file(
 		name: meson.project_name(),
 		input: 'cmake'/'tomlplusplus.cmake.in',
-		configuration: cmake_conf,
-		install_dir: 'lib'/'cmake'/meson.project_name(),
+		configuration: configuration_data(), # empty conf, not needed
+		install_dir: get_option('datadir')/'cmake'/meson.project_name(),
 	)
 endif

--- a/meson.build
+++ b/meson.build
@@ -540,14 +540,13 @@ if get_option('generate_cmake_config') and not is_subproject
 		configuration: {'version': meson.project_version()},
 		input: 'cmake'/'tomlplusplusConfigVersion.cmake.in',
 		output: 'tomlplusplusConfigVersion.cmake',
-		install: true,
 		install_dir: get_option('datadir')/'cmake'/meson.project_name()
 	)
 
 	cmake.configure_package_config_file(
 		name: meson.project_name(),
 		input: 'cmake'/'tomlplusplus.cmake.in',
-		configuration: configuration_data(), # empty conf, not needed
+		configuration: configuration_data({'includedir': get_option('includedir')}),
 		install_dir: get_option('datadir')/'cmake'/meson.project_name(),
 	)
 endif


### PR DESCRIPTION
Since Meson doesn't yet support CMake's `ARCH_INDEPENDENT` option, a pre-generated Package Version file is installed instead of generating it at configure time.

I've also cleaned up a bit the nearby lines of code.

Fixes #140

**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md