### PR TITLE
clang 10.0: error: unknown warning group '-Wsuggest-destructor-override' #145

### DIFF
--- a/include/toml++/impl/preprocessor.h
+++ b/include/toml++/impl/preprocessor.h
@@ -75,14 +75,22 @@
 	#if TOML_CLANG >= 10
 		#define TOML_DISABLE_SPAM_WARNINGS_CLANG_10 \
 			_Pragma("clang diagnostic ignored \"-Wzero-as-null-pointer-constant\"") \
-			_Pragma("clang diagnostic ignored \"-Wsuggest-destructor-override\"") \
 			static_assert(true)
 	#else
 		#define TOML_DISABLE_SPAM_WARNINGS_CLANG_10 static_assert(true)
 	#endif
 
+	#if TOML_CLANG >= 11
+		#define TOML_DISABLE_SPAM_WARNINGS_CLANG_11 \
+			_Pragma("clang diagnostic ignored \"-Wsuggest-destructor-override\"") \
+			static_assert(true)
+	#else
+		#define TOML_DISABLE_SPAM_WARNINGS_CLANG_11 static_assert(true)
+	#endif
+
 	#define TOML_DISABLE_SPAM_WARNINGS \
 		TOML_DISABLE_SPAM_WARNINGS_CLANG_10; \
+		TOML_DISABLE_SPAM_WARNINGS_CLANG_11; \
 		_Pragma("clang diagnostic ignored \"-Wweak-vtables\"")	\
 		_Pragma("clang diagnostic ignored \"-Wweak-template-vtables\"") \
 		_Pragma("clang diagnostic ignored \"-Wdouble-promotion\"") \


### PR DESCRIPTION
- [ x] I've read [CONTRIBUTING.md]
- [ x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md