### PR TITLE
Move install rules under PROJECT_IS_TOP_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,13 +30,9 @@ target_include_directories(
 
 target_compile_features(tomlplusplus_tomlplusplus INTERFACE cxx_std_17)
 
-# ---- Install rules ----
-
-include(cmake/install-rules.cmake)
-
-# ---- Examples ----
-
+# ---- Install rules and examples ----
 if(PROJECT_IS_TOP_LEVEL)
+  include(cmake/install-rules.cmake)
   option(BUILD_EXAMPLES "Build examples tree." OFF)
   if(BUILD_EXAMPLES)
     add_subdirectory(examples)


### PR DESCRIPTION
**What does this change do?** I moved install rules under `PROJECT_IS_TOP_LEVEL` check. Otherwise using `FetchContent` it will generate install rule for this library which is unnecessary since the library is already added to the project.

**Pre-merge checklist**
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change (unnecessary)
- [ ] I've regenerated toml.hpp ([how-to]) (unnecessary)
- [ ] I've updated any affected documentation (unnecessary)
- [ ] I've rebuilt and run the tests with at least one of:  (unnecessary)
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)  (unnecessary, it's a super minor change)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md