### PR TITLE
added operator= for path_components to keep component type and value synchronized

### DIFF
--- a/include/toml++/impl/path.h
+++ b/include/toml++/impl/path.h
@@ -46,7 +46,7 @@ TOML_NAMESPACE_START
 		/// \brief	Constructor for a path component that is an array index
 		TOML_NODISCARD_CTOR
 		TOML_EXPORTED_MEMBER_FUNCTION
-		path_component(size_t index);
+		path_component(size_t index) noexcept;
 
 		/// \brief	Constructor for a path component that is a key string
 		TOML_NODISCARD_CTOR
@@ -64,14 +64,14 @@ TOML_NAMESPACE_START
 
 		/// \brief Retrieve the value of this path component, either the key name or the aray index
 		TOML_PURE_INLINE_GETTER
-		const path_component_value& get_value() const noexcept
+		const path_component_value& value() const noexcept
 		{
 			return value_;
 		}
 
 		/// \brief Retrieve the type of this path component, either path_component::key or path_component::array_index
 		TOML_PURE_INLINE_GETTER
-		path_component_type get_type() const noexcept
+		path_component_type type() const noexcept
 		{
 			return type_;
 		}

--- a/include/toml++/impl/path.h
+++ b/include/toml++/impl/path.h
@@ -23,8 +23,7 @@ TOML_NAMESPACE_START
 	using path_component_value = std::variant<std::string, size_t>;
 
 	/// \brief Represents a single component of a complete 'TOML-path': either a key or an array index
-	TOML_EXPORTED_CLASS
-	struct path_component
+	struct TOML_EXPORTED_CLASS path_component
 	{
 		friend class path;
 

--- a/include/toml++/impl/path.h
+++ b/include/toml++/impl/path.h
@@ -25,11 +25,13 @@ TOML_NAMESPACE_START
 	/// \brief Represents a single component of a complete 'TOML-path': either a key or an array index
 	struct path_component
 	{
-		path_component_value value;
-		path_component_type type;
+		friend class path;
 
 	  private:
 		/// \cond
+
+	  	path_component_value value_;
+		path_component_type type_;
 
 		TOML_PURE_GETTER
 		TOML_EXPORTED_STATIC_FUNCTION
@@ -37,6 +39,29 @@ TOML_NAMESPACE_START
 
 		/// \endcond
 	  public:
+		/// \brief	Default constructor.
+		TOML_NODISCARD_CTOR
+		path_component() noexcept = default;
+
+		/// \brief	Constructor with path component fields specified.
+		TOML_NODISCARD_CTOR
+		TOML_EXPORTED_MEMBER_FUNCTION
+		path_component(path_component_value value, path_component_type type);
+
+		/// \brief Retrieve the value of this path component, either the key name or the aray index
+		TOML_PURE_INLINE_GETTER
+		const path_component_value& get_value() const noexcept
+		{
+			return value_;
+		}
+
+		/// \brief Retrieve the type of this path component, either path_component::key or path_component::array_index
+		TOML_PURE_INLINE_GETTER
+		path_component_type get_type() const noexcept
+		{
+			return type_;
+		}
+
 		/// \brief	Returns true if two path components represent the same key or array index.
 		TOML_PURE_INLINE_GETTER
 		friend bool operator==(const path_component& lhs, const path_component& rhs) noexcept
@@ -50,6 +75,20 @@ TOML_NAMESPACE_START
 		{
 			return !equal(lhs, rhs);
 		}
+
+		/// \brief Assigns an array index to this path component. Index must castable to size_t
+		path_component& operator=(size_t index) noexcept;
+
+		/// \brief Assigns a path key to this path component. Key must be a string type
+		path_component& operator=(std::string_view key);
+
+#if TOML_ENABLE_WINDOWS_COMPAT
+
+		/// \brief Assigns a path key to this path component using window wide char strings. Key must be a wide char string type
+		path_component& operator=(std::wstring_view key);
+
+#endif
+
 	};
 
 	/// \brief	A TOML path.

--- a/include/toml++/impl/path.h
+++ b/include/toml++/impl/path.h
@@ -77,14 +77,17 @@ TOML_NAMESPACE_START
 		}
 
 		/// \brief Assigns an array index to this path component. Index must castable to size_t
+		TOML_EXPORTED_MEMBER_FUNCTION
 		path_component& operator=(size_t index) noexcept;
 
 		/// \brief Assigns a path key to this path component. Key must be a string type
+		TOML_EXPORTED_MEMBER_FUNCTION
 		path_component& operator=(std::string_view key);
 
 #if TOML_ENABLE_WINDOWS_COMPAT
 
 		/// \brief Assigns a path key to this path component using window wide char strings. Key must be a wide char string type
+		TOML_EXPORTED_MEMBER_FUNCTION
 		path_component& operator=(std::wstring_view key);
 
 #endif

--- a/include/toml++/impl/path.h
+++ b/include/toml++/impl/path.h
@@ -43,10 +43,24 @@ TOML_NAMESPACE_START
 		TOML_NODISCARD_CTOR
 		path_component() noexcept = default;
 
-		/// \brief	Constructor with path component fields specified.
+		/// \brief	Constructor for a path component that is an array index
 		TOML_NODISCARD_CTOR
 		TOML_EXPORTED_MEMBER_FUNCTION
-		path_component(path_component_value value, path_component_type type);
+		path_component(size_t index);
+
+		/// \brief	Constructor for a path component that is a key string
+		TOML_NODISCARD_CTOR
+		TOML_EXPORTED_MEMBER_FUNCTION
+		path_component(std::string_view key);
+
+#if TOML_ENABLE_WINDOWS_COMPAT
+
+		/// \brief	Constructor for a path component that is a key specified witha wide-char string
+		TOML_NODISCARD_CTOR
+		TOML_EXPORTED_MEMBER_FUNCTION
+		path_component(std::wstring_view key);
+
+#endif
 
 		/// \brief Retrieve the value of this path component, either the key name or the aray index
 		TOML_PURE_INLINE_GETTER

--- a/include/toml++/impl/path.h
+++ b/include/toml++/impl/path.h
@@ -23,6 +23,7 @@ TOML_NAMESPACE_START
 	using path_component_value = std::variant<std::string, size_t>;
 
 	/// \brief Represents a single component of a complete 'TOML-path': either a key or an array index
+	TOML_EXPORTED_CLASS
 	struct path_component
 	{
 		friend class path;

--- a/include/toml++/impl/path.inl
+++ b/include/toml++/impl/path.inl
@@ -29,8 +29,20 @@ TOML_ENABLE_WARNINGS;
 TOML_NAMESPACE_START
 {
 	TOML_EXTERNAL_LINKAGE
-	path_component::path_component(path_component_value value, path_component_type type) : value_(value), type_(type)
+	path_component::path_component(size_t index) : value_(index), type_(path_component_type::array_index)
 	{ }
+
+	TOML_EXTERNAL_LINKAGE
+	path_component::path_component(std::string_view key) : value_(key.data()), type_(path_component_type::key)
+	{ }
+
+#if TOML_ENABLE_WINDOWS_COMPAT
+
+	TOML_EXTERNAL_LINKAGE
+	path_component::path_component(std::wstring_view key) : value_(impl::narrow(key)), type_(path_component_type::key)
+	{ }
+
+#endif
 
 	TOML_EXTERNAL_LINKAGE
 	bool TOML_CALLCONV path_component::equal(const path_component& lhs, const path_component& rhs) noexcept
@@ -85,14 +97,14 @@ TOML_ANON_NAMESPACE_START
 		static constexpr auto on_key = [](void* data, std::string_view key) -> bool
 		{
 			auto& comps = *static_cast<components_type*>(data);
-			comps.emplace_back(path_component{ std::string(key), path_component_type::key });
+			comps.emplace_back(path_component{ std::string(key) });
 			return true;
 		};
 
 		static constexpr auto on_index = [](void* data, size_t index) -> bool
 		{
 			auto& comps = *static_cast<components_type*>(data);
-			comps.emplace_back(path_component{ index, path_component_type::array_index });
+			comps.emplace_back(path_component{ index });
 			return true;
 		};
 

--- a/include/toml++/impl/path.inl
+++ b/include/toml++/impl/path.inl
@@ -29,10 +29,43 @@ TOML_ENABLE_WARNINGS;
 TOML_NAMESPACE_START
 {
 	TOML_EXTERNAL_LINKAGE
+	path_component::path_component(path_component_value value, path_component_type type) : value_(value), type_(type)
+	{ }
+
+	TOML_EXTERNAL_LINKAGE
 	bool TOML_CALLCONV path_component::equal(const path_component& lhs, const path_component& rhs) noexcept
 	{
-		return lhs.type == rhs.type && lhs.value == rhs.value;
+		return lhs.type_ == rhs.type_ && lhs.value_ == rhs.value_;
 	}
+
+	TOML_EXTERNAL_LINKAGE
+	path_component& path_component::operator = (size_t index) noexcept
+	{
+		value_ = static_cast<size_t>(index);
+		type_  = path_component_type::array_index;
+		return *this;
+	}
+
+	TOML_EXTERNAL_LINKAGE
+	path_component& path_component::operator= (std::string_view key)
+	{
+		value_ = std::string(key);
+		type_  = path_component_type::key;
+		return *this;
+	}
+
+#if TOML_ENABLE_WINDOWS_COMPAT
+
+	TOML_EXTERNAL_LINKAGE
+	path_component& path_component::operator= (std::wstring_view key)
+	{
+		value_ = std::string(impl::narrow(key));
+		type_  = path_component_type::key;
+		return *this;
+	}
+
+#endif
+
 }
 TOML_NAMESPACE_END;
 
@@ -82,16 +115,16 @@ TOML_NAMESPACE_START
 		bool root = true;
 		for (const auto& component : components_)
 		{
-			if (component.type == path_component_type::key) // key
+			if (component.type_ == path_component_type::key) // key
 			{
 				if (!root)
 					impl::print_to_stream(os, '.');
-				impl::print_to_stream(os, std::get<std::string>(component.value));
+				impl::print_to_stream(os, std::get<std::string>(component.value_));
 			}
-			else if (component.type == path_component_type::array_index) // array
+			else if (component.type_ == path_component_type::array_index) // array
 			{
 				impl::print_to_stream(os, '[');
-				impl::print_to_stream(os, std::get<size_t>(component.value));
+				impl::print_to_stream(os, std::get<size_t>(component.value_));
 				impl::print_to_stream(os, ']');
 			}
 			root = false;
@@ -333,22 +366,22 @@ TOML_NAMESPACE_START
 
 		for (const auto& component : path)
 		{
-			auto type = component.type;
-			if (type == path_component_type::array_index && std::holds_alternative<size_t>(component.value))
+			auto type = component.get_type();
+			if (type == path_component_type::array_index && std::holds_alternative<size_t>(component.get_value()))
 			{
 				const auto current_array = current->as<array>();
 				if (!current_array)
 					return {}; // not an array, using array index doesn't work
 
-				current = current_array->get(std::get<size_t>(component.value));
+				current = current_array->get(std::get<size_t>(component.get_value()));
 			}
-			else if (type == path_component_type::key && std::holds_alternative<std::string>(component.value))
+			else if (type == path_component_type::key && std::holds_alternative<std::string>(component.get_value()))
 			{
 				const auto current_table = current->as<table>();
 				if (!current_table)
 					return {};
 
-				current = current_table->get(std::get<std::string>(component.value));
+				current = current_table->get(std::get<std::string>(component.get_value()));
 			}
 			else
 			{

--- a/include/toml++/impl/path.inl
+++ b/include/toml++/impl/path.inl
@@ -39,7 +39,7 @@ TOML_NAMESPACE_START
 	}
 
 	TOML_EXTERNAL_LINKAGE
-	path_component& path_component::operator = (size_t index) noexcept
+	path_component& path_component::operator= (size_t index) noexcept
 	{
 		value_ = static_cast<size_t>(index);
 		type_  = path_component_type::array_index;

--- a/include/toml++/impl/path.inl
+++ b/include/toml++/impl/path.inl
@@ -29,11 +29,11 @@ TOML_ENABLE_WARNINGS;
 TOML_NAMESPACE_START
 {
 	TOML_EXTERNAL_LINKAGE
-	path_component::path_component(size_t index) : value_(index), type_(path_component_type::array_index)
+	path_component::path_component(size_t index) noexcept : value_(index), type_(path_component_type::array_index)
 	{ }
 
 	TOML_EXTERNAL_LINKAGE
-	path_component::path_component(std::string_view key) : value_(key.data()), type_(path_component_type::key)
+	path_component::path_component(std::string_view key) : value_(std::string(key)), type_(path_component_type::key)
 	{ }
 
 #if TOML_ENABLE_WINDOWS_COMPAT
@@ -97,14 +97,14 @@ TOML_ANON_NAMESPACE_START
 		static constexpr auto on_key = [](void* data, std::string_view key) -> bool
 		{
 			auto& comps = *static_cast<components_type*>(data);
-			comps.emplace_back(path_component{ std::string(key) });
+			comps.emplace_back(key);
 			return true;
 		};
 
 		static constexpr auto on_index = [](void* data, size_t index) -> bool
 		{
 			auto& comps = *static_cast<components_type*>(data);
-			comps.emplace_back(path_component{ index });
+			comps.emplace_back(index);
 			return true;
 		};
 
@@ -378,22 +378,22 @@ TOML_NAMESPACE_START
 
 		for (const auto& component : path)
 		{
-			auto type = component.get_type();
-			if (type == path_component_type::array_index && std::holds_alternative<size_t>(component.get_value()))
+			auto type = component.type();
+			if (type == path_component_type::array_index && std::holds_alternative<size_t>(component.value()))
 			{
 				const auto current_array = current->as<array>();
 				if (!current_array)
 					return {}; // not an array, using array index doesn't work
 
-				current = current_array->get(std::get<size_t>(component.get_value()));
+				current = current_array->get(std::get<size_t>(component.value()));
 			}
-			else if (type == path_component_type::key && std::holds_alternative<std::string>(component.get_value()))
+			else if (type == path_component_type::key && std::holds_alternative<std::string>(component.value()))
 			{
 				const auto current_table = current->as<table>();
 				if (!current_table)
 					return {};
 
-				current = current_table->get(std::get<std::string>(component.get_value()));
+				current = current_table->get(std::get<std::string>(component.value()));
 			}
 			else
 			{

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -295,16 +295,17 @@ TEST_CASE("path - manipulating")
 	{
 		toml::path p0("start.mid[1][2].end");
 
-		p0[3].value = std::size_t{ 13 };
+		p0[3] = std::size_t{ 13 };
 		CHECK(p0.str() == "start.mid[1][13].end");
 
-		p0[3].type	= path_component_type::key;
-		p0[3].value = "newkey";
-		CHECK(p0.str() == "start.mid[1].newkey.end");
+		p0[0] = 2u;
+		CHECK(p0.str() == "[2].mid[1][13].end");
 
-		p0[0].value = std::size_t{ 2 };
-		p0[0].type	= path_component_type::array_index;
-		CHECK(p0.str() == "[2].mid[1].newkey.end");
+		p0[0] = 10;
+		CHECK(p0.str() == "[10].mid[1][13].end");
+
+		p0[3] = "newkey";
+		CHECK(p0.str() == "[10].mid[1].newkey.end");
 	}
 
 	SECTION("assign")
@@ -581,14 +582,4 @@ TEST_CASE("path - accessing")
 		CHECK(tbl["d"][""] == tbl[toml::path("d.")]);
 	}
 
-	SECTION("std::variant mismatches")
-	{
-		toml::path p0("b[2].c");
-		p0[1].value = "abc";
-		CHECK(!at_path(tbl, p0));
-
-		toml::path p1("b[2].c");
-		p1[0].value = std::size_t{ 1 };
-		CHECK(!at_path(tbl, p1));
-	}
 }

--- a/toml.hpp
+++ b/toml.hpp
@@ -2754,14 +2754,16 @@ TOML_NAMESPACE_START
 			return !equal(lhs, rhs);
 		}
 
+		TOML_EXPORTED_MEMBER_FUNCTION
 		path_component& operator=(size_t index) noexcept;
 
+		TOML_EXPORTED_MEMBER_FUNCTION
 		path_component& operator=(std::string_view key);
 
 #if TOML_ENABLE_WINDOWS_COMPAT
 
+		TOML_EXPORTED_MEMBER_FUNCTION
 		path_component& operator=(std::wstring_view key);
-
 #endif
 	};
 
@@ -10522,7 +10524,7 @@ TOML_NAMESPACE_START
 	}
 
 	TOML_EXTERNAL_LINKAGE
-	path_component& path_component::operator = (size_t index) noexcept
+	path_component& path_component::operator= (size_t index) noexcept
 	{
 		value_ = static_cast<size_t>(index);
 		type_  = path_component_type::array_index;

--- a/toml.hpp
+++ b/toml.hpp
@@ -2708,8 +2708,7 @@ TOML_NAMESPACE_START
 
 	using path_component_value = std::variant<std::string, size_t>;
 
-	TOML_EXPORTED_CLASS
-	struct path_component
+	struct TOML_EXPORTED_CLASS path_component
 	{
 		friend class path;
 

--- a/toml.hpp
+++ b/toml.hpp
@@ -2710,16 +2710,37 @@ TOML_NAMESPACE_START
 
 	struct path_component
 	{
-		path_component_value value;
-		path_component_type type;
+		friend class path;
 
 	  private:
+
+	  	path_component_value value_;
+		path_component_type type_;
 
 		TOML_PURE_GETTER
 		TOML_EXPORTED_STATIC_FUNCTION
 		static bool TOML_CALLCONV equal(const path_component&, const path_component&) noexcept;
 
 	  public:
+
+		TOML_NODISCARD_CTOR
+		path_component() noexcept = default;
+
+		TOML_NODISCARD_CTOR
+		TOML_EXPORTED_MEMBER_FUNCTION
+		path_component(path_component_value value, path_component_type type);
+
+		TOML_PURE_INLINE_GETTER
+		const path_component_value& get_value() const noexcept
+		{
+			return value_;
+		}
+
+		TOML_PURE_INLINE_GETTER
+		path_component_type get_type() const noexcept
+		{
+			return type_;
+		}
 
 		TOML_PURE_INLINE_GETTER
 		friend bool operator==(const path_component& lhs, const path_component& rhs) noexcept
@@ -2732,6 +2753,16 @@ TOML_NAMESPACE_START
 		{
 			return !equal(lhs, rhs);
 		}
+
+		path_component& operator=(size_t index) noexcept;
+
+		path_component& operator=(std::string_view key);
+
+#if TOML_ENABLE_WINDOWS_COMPAT
+
+		path_component& operator=(std::wstring_view key);
+
+#endif
 	};
 
 	class TOML_EXPORTED_CLASS path
@@ -10481,10 +10512,42 @@ TOML_PUSH_WARNINGS;
 TOML_NAMESPACE_START
 {
 	TOML_EXTERNAL_LINKAGE
+	path_component::path_component(path_component_value value, path_component_type type) : value_(value), type_(type)
+	{ }
+
+	TOML_EXTERNAL_LINKAGE
 	bool TOML_CALLCONV path_component::equal(const path_component& lhs, const path_component& rhs) noexcept
 	{
-		return lhs.type == rhs.type && lhs.value == rhs.value;
+		return lhs.type_ == rhs.type_ && lhs.value_ == rhs.value_;
 	}
+
+	TOML_EXTERNAL_LINKAGE
+	path_component& path_component::operator = (size_t index) noexcept
+	{
+		value_ = static_cast<size_t>(index);
+		type_  = path_component_type::array_index;
+		return *this;
+	}
+
+	TOML_EXTERNAL_LINKAGE
+	path_component& path_component::operator= (std::string_view key)
+	{
+		value_ = std::string(key);
+		type_  = path_component_type::key;
+		return *this;
+	}
+
+#if TOML_ENABLE_WINDOWS_COMPAT
+
+	TOML_EXTERNAL_LINKAGE
+	path_component& path_component::operator= (std::wstring_view key)
+	{
+		value_ = std::string(impl::narrow(key));
+		type_  = path_component_type::key;
+		return *this;
+	}
+
+#endif
 }
 TOML_NAMESPACE_END;
 
@@ -10530,16 +10593,16 @@ TOML_NAMESPACE_START
 		bool root = true;
 		for (const auto& component : components_)
 		{
-			if (component.type == path_component_type::key) // key
+			if (component.type_ == path_component_type::key) // key
 			{
 				if (!root)
 					impl::print_to_stream(os, '.');
-				impl::print_to_stream(os, std::get<std::string>(component.value));
+				impl::print_to_stream(os, std::get<std::string>(component.value_));
 			}
-			else if (component.type == path_component_type::array_index) // array
+			else if (component.type_ == path_component_type::array_index) // array
 			{
 				impl::print_to_stream(os, '[');
-				impl::print_to_stream(os, std::get<size_t>(component.value));
+				impl::print_to_stream(os, std::get<size_t>(component.value_));
 				impl::print_to_stream(os, ']');
 			}
 			root = false;
@@ -10765,22 +10828,22 @@ TOML_NAMESPACE_START
 
 		for (const auto& component : path)
 		{
-			auto type = component.type;
-			if (type == path_component_type::array_index && std::holds_alternative<size_t>(component.value))
+			auto type = component.get_type();
+			if (type == path_component_type::array_index && std::holds_alternative<size_t>(component.get_value()))
 			{
 				const auto current_array = current->as<array>();
 				if (!current_array)
 					return {}; // not an array, using array index doesn't work
 
-				current = current_array->get(std::get<size_t>(component.value));
+				current = current_array->get(std::get<size_t>(component.get_value()));
 			}
-			else if (type == path_component_type::key && std::holds_alternative<std::string>(component.value))
+			else if (type == path_component_type::key && std::holds_alternative<std::string>(component.get_value()))
 			{
 				const auto current_table = current->as<table>();
 				if (!current_table)
 					return {};
 
-				current = current_table->get(std::get<std::string>(component.value));
+				current = current_table->get(std::get<std::string>(component.get_value()));
 			}
 			else
 			{

--- a/toml.hpp
+++ b/toml.hpp
@@ -2708,6 +2708,7 @@ TOML_NAMESPACE_START
 
 	using path_component_value = std::variant<std::string, size_t>;
 
+	TOML_EXPORTED_CLASS
 	struct path_component
 	{
 		friend class path;


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->



**What does this change do?**
Improve path_component assignments and safety



**Is it related to an exisiting bug report or feature request?**
#153 



**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [ ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [x] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [x] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md