### PR TITLE
Revert "build(meson): Update path for .pc and .cmake files (#165)"

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -6,6 +6,7 @@ if not is_subproject
 	import('pkgconfig').generate(
 		name: meson.project_name(),
 		description: 'Header-only TOML config file parser and serializer for C++',
+		install_dir: get_option('datadir')/'pkgconfig',
 		url: 'https://marzer.github.io/tomlplusplus'
 	)
 endif
@@ -18,7 +19,7 @@ if get_option('generate_cmake_config') and not is_subproject
 	#cmake.write_basic_package_version_file(
 	#	name: meson.project_name(),
 	#	version: meson.project_version(),
-	#	install_dir: get_option('libdir')/'cmake'/meson.project_name(),
+	#	install_dir: get_option('datadir')/'cmake'/meson.project_name(),
 	#	arch_independent: true
 	#)
 	# In the meantime, install a pre-generated Package Version file
@@ -26,13 +27,13 @@ if get_option('generate_cmake_config') and not is_subproject
 		configuration: {'version': meson.project_version()},
 		input: '..'/'cmake'/'tomlplusplusConfigVersion.cmake.meson.in',
 		output: 'tomlplusplusConfigVersion.cmake',
-		install_dir: get_option('libdir')/'cmake'/meson.project_name()
+		install_dir: get_option('datadir')/'cmake'/meson.project_name()
 	)
 
 	cmake.configure_package_config_file(
 		name: meson.project_name(),
 		input: '..'/'cmake'/'tomlplusplusConfig.cmake.meson.in',
 		configuration: configuration_data({'includedir': get_option('includedir')}),
-		install_dir: get_option('libdir')/'cmake'/meson.project_name(),
+		install_dir: get_option('datadir')/'cmake'/meson.project_name(),
 	)
 endif


### PR DESCRIPTION
If you want to read the full story please see pull request #165, but in short moving files from `share/` to `lib/` was needed because FreeBSD didn't look for .pc files in `share/pkgconfig/`.

After a quick [discussion][] upstream, FreeBSD's [pkgconf was patched][] to also honour .pc files in `share/pkgconfig/`.

Now that everybody looks for stuff in `share/`, the commit b1ecdf0ed86faeeaebe13d0db16ad04c20519527 can be reverted, so that stuff like cross-compilation can continue working fine.

[discussion]: https://lists.freebsd.org/archives/freebsd-hackers/2022-July/001355.html
[pkgconf was patched]: https://github.com/freebsd/freebsd-ports/commit/d48fab59daa56e0b3b6ffecef57a69c32ae9c0a7