### PR TITLE
Update at_path(toml::path) to handle missing component

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 - **[@bobfang1992](https://github.com/bobfang1992)** - Reported a bug and created a [wrapper in python](https://github.com/bobfang1992/pytomlpp)
 - **[@GiulioRomualdi](https://github.com/GiulioRomualdi)** - Added cmake+meson support
 - **[@jonestristand](https://github.com/jonestristand)** - Designed and implemented the `toml::path`s feature
+- **[@kcsaul](https://github.com/kcsaul)** - Fixed a bug
 - **[@levicki](https://github.com/levicki)** - Helped design some new features
 - **[@moorereason](https://github.com/moorereason)** - Reported a whole bunch of bugs
 - **[@mosra](https://github.com/mosra)** - Created the awesome [m.css] used to generate the API docs

--- a/include/toml++/impl/path.inl
+++ b/include/toml++/impl/path.inl
@@ -504,6 +504,9 @@ TOML_NAMESPACE_START
 				// Error: invalid component
 				return {};
 			}
+
+			if (!current)
+				return {}; // not found
 		}
 
 		return node_view{ current };

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -510,6 +510,8 @@ TEST_CASE("path - accessing")
 
 		CHECK(tbl["d"][""]);
 		CHECK(tbl["d"][""] == at_path(tbl, toml::path("d.")));
+
+		CHECK(!at_path(tbl, toml::path("has.missing.component")));
 	}
 
 	SECTION("array")
@@ -535,6 +537,8 @@ TEST_CASE("path - accessing")
 		CHECK(tbl["b"][2]["c"]);
 		CHECK(tbl["b"][2]["c"] == arr.at_path(toml::path("[2].c")));
 		CHECK(tbl["b"][2]["c"] == arr.at_path(toml::path("[2]   \t.c"))); // whitespace is allowed after array indexers
+
+		CHECK(!arr.at_path(toml::path("[3].missing.component")));
 	}
 
 	SECTION("indexing operator")
@@ -580,5 +584,7 @@ TEST_CASE("path - accessing")
 
 		CHECK(tbl["d"][""]);
 		CHECK(tbl["d"][""] == tbl[toml::path("d.")]);
+
+		CHECK(!tbl[toml::path("has.missing.component")]);
 	}
 }

--- a/toml.hpp
+++ b/toml.hpp
@@ -11161,6 +11161,9 @@ TOML_NAMESPACE_START
 				// Error: invalid component
 				return {};
 			}
+
+			if (!current)
+				return {}; // not found
 		}
 
 		return node_view{ current };


### PR DESCRIPTION
**What does this change do?**
Fix seg fault within at_path(toml::path) when there's a missing component

**Is it related to an existing bug report or feature request?**
No, new bug identified

**Pre-merge checklist**
- [x] I've read [CONTRIBUTING.md]
- [ ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [x] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [x] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md