### PR TITLE
Suppress -Wduplicated-branches

### DIFF
--- a/include/toml++/impl/preprocessor.h
+++ b/include/toml++/impl/preprocessor.h
@@ -577,6 +577,7 @@
 	TOML_PRAGMA_GCC(diagnostic ignored "-Wmaybe-uninitialized")                                                        \
 	TOML_PRAGMA_GCC(diagnostic ignored "-Wnoexcept")                                                                   \
 	TOML_PRAGMA_GCC(diagnostic ignored "-Wnull-dereference")                                                           \
+	TOML_PRAGMA_GCC(diagnostic ignored "-Wduplicated-branches")                                                        \
 	static_assert(true)
 
 #define TOML_POP_WARNINGS                                                                                              \

--- a/toml.hpp
+++ b/toml.hpp
@@ -607,6 +607,7 @@
 	TOML_PRAGMA_GCC(diagnostic ignored "-Wmaybe-uninitialized")                                                        \
 	TOML_PRAGMA_GCC(diagnostic ignored "-Wnoexcept")                                                                   \
 	TOML_PRAGMA_GCC(diagnostic ignored "-Wnull-dereference")                                                           \
+	TOML_PRAGMA_GCC(diagnostic ignored "-Wduplicated-branches")                                                        \
 	static_assert(true)
 
 #define TOML_POP_WARNINGS                                                                                              \


### PR DESCRIPTION
Solves:
tomlplusplus/include/toml++/impl/path.h:29:73: warning: this condition has identical branches [-Wduplicated-branches]
   29 |                                 (alignof(size_t) < alignof(std::string) ? alignof(std::string) : alignof(size_t));

<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->



**What does this change do?**
Fix a Warning.


**Is it related to an exisiting bug report or feature request?**
Nope



**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [X] I've read [CONTRIBUTING.md]
- [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to]) - Could not, the pip command does not run successfully, and no energy to fix that.
- [X] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md