### PR TITLE
Fix typo in at_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 - **[@traversaro](https://github.com/traversaro)** - Added vcpkg support and reported a bunch of bugs
 - **[@whiterabbit963](https://github.com/whiterabbit963)** - Fixed a bug with value_or conversions
 - **[@ximion](https://github.com/ximion)** - Added support for installation with meson
+- **[@a-is](https://github.com/a-is)** - Fixed a bug
 
 <br>
 

--- a/include/toml++/impl/at_path.inl
+++ b/include/toml++/impl/at_path.inl
@@ -97,7 +97,7 @@ TOML_IMPL_NAMESPACE_START
 					}
 					else if TOML_UNLIKELY(c == '.' || c == '[')
 						break;
-					else if (c == '\t' || c == '.')
+					else if (c == '\t' || c == ' ')
 						pos++;
 					else
 						return false;

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -16,6 +16,7 @@ TEST_CASE("path - parsing")
 		CHECK(toml::path("  [1][2]").str() == "  [1][2]");
 		CHECK(toml::path("a.  .b").str() == "a.  .b");
 		CHECK(toml::path("test[23]").str() == "test[23]");
+		CHECK(toml::path("[ 120  ]").str() == "[120]");
 		CHECK(toml::path("[ 120\t\t]").str() == "[120]");
 		CHECK(toml::path("test.value").str() == "test.value");
 		CHECK(toml::path("test[0].value").str() == "test[0].value");
@@ -31,6 +32,7 @@ TEST_CASE("path - parsing")
 		CHECK(toml::path(L"  [1][2]").str() == "  [1][2]");
 		CHECK(toml::path(L"a.  .b").str() == "a.  .b");
 		CHECK(toml::path(L"test[23]").str() == "test[23]");
+		CHECK(toml::path(L"[ 120  ]").str() == "[120]");
 		CHECK(toml::path(L"[ 120\t\t]").str() == "[120]");
 		CHECK(toml::path(L"test.value").str() == "test.value");
 		CHECK(toml::path(L"test[0].value").str() == "test[0].value");

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -16,7 +16,7 @@ TEST_CASE("path - parsing")
 		CHECK(toml::path("  [1][2]").str() == "  [1][2]");
 		CHECK(toml::path("a.  .b").str() == "a.  .b");
 		CHECK(toml::path("test[23]").str() == "test[23]");
-		CHECK(toml::path("[ 120		]").str() == "[120]");
+		CHECK(toml::path("[ 120\t\t]").str() == "[120]");
 		CHECK(toml::path("test.value").str() == "test.value");
 		CHECK(toml::path("test[0].value").str() == "test[0].value");
 		CHECK(toml::path("test[1][2]\t .value").str() == "test[1][2].value");
@@ -31,7 +31,7 @@ TEST_CASE("path - parsing")
 		CHECK(toml::path(L"  [1][2]").str() == "  [1][2]");
 		CHECK(toml::path(L"a.  .b").str() == "a.  .b");
 		CHECK(toml::path(L"test[23]").str() == "test[23]");
-		CHECK(toml::path(L"[ 120		]").str() == "[120]");
+		CHECK(toml::path(L"[ 120\t\t]").str() == "[120]");
 		CHECK(toml::path(L"test.value").str() == "test.value");
 		CHECK(toml::path(L"test[0].value").str() == "test[0].value");
 		CHECK(toml::path(L"test[1][2]\t .value").str() == "test[1][2].value");

--- a/toml.hpp
+++ b/toml.hpp
@@ -10490,7 +10490,7 @@ TOML_IMPL_NAMESPACE_START
 					}
 					else if TOML_UNLIKELY(c == '.' || c == '[')
 						break;
-					else if (c == '\t' || c == '.')
+					else if (c == '\t' || c == ' ')
 						pos++;
 					else
 						return false;


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->



**What does this change do?**
Using a static code analyzer, a suspicious place was discovered:
```cpp
if (c == ']')
{
    pos++;
    break;
}
else if TOML_UNLIKELY(c == '.' || c == '[')
//                    ^^^^^^^^
    break;
else if (c == '\t' || c == '.')
//                    ^^^^^^^^
    pos++;
else
    return false;
```

Obviously, a mistake was made in one of the places. It is easy to see that in the second case, whitespace characters are checked, so there should be a space (`' '`) instead of a dot (`'.'`). This PR fixing bug, adds a test.




**Is it related to an exisiting bug report or feature request?**
No, I created a PR without creating an issue



**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [x] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [x] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [x] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md