### PR TITLE
fix build with mingw g++ 10

### DIFF
--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -3763,7 +3763,7 @@ TOML_ANON_NAMESPACE_START
 		TOML_OVERALIGNED char file_buffer[sizeof(void*) * 1024u];
 		file.rdbuf()->pubsetbuf(file_buffer, sizeof(file_buffer));
 #if TOML_WINDOWS
-		file.open(impl::widen(file_path_str), std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
+		file.open(impl::widen(file_path_str).c_str(), std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
 #else
 		file.open(file_path_str, std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
 #endif

--- a/toml.hpp
+++ b/toml.hpp
@@ -15772,7 +15772,7 @@ TOML_ANON_NAMESPACE_START
 		TOML_OVERALIGNED char file_buffer[sizeof(void*) * 1024u];
 		file.rdbuf()->pubsetbuf(file_buffer, sizeof(file_buffer));
 #if TOML_WINDOWS
-		file.open(impl::widen(file_path_str), std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
+		file.open(impl::widen(file_path_str).c_str(), std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
 #else
 		file.open(file_path_str, std::ifstream::in | std::ifstream::binary | std::ifstream::ate);
 #endif


### PR DESCRIPTION
**What does this change do?**

Adds `c_str()` for compatibility with mingw, which doesn't have `wstring` overload for `open()`, but does have a `wchar_t *` overload.


**Is it related to an exisiting bug report or feature request?**

Fixes: <https://github.com/marzer/tomlplusplus/issues/182>


**Pre-merge checklist**
- [X] I've read [CONTRIBUTING.md]
- [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [ ] I've regenerated toml.hpp ([how-to])
    - [X] (I made duplicate changes by hand...)
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md