### PR TITLE
do not use inline_recursion if using clang

### DIFF
--- a/include/toml++/impl/header_end.h
+++ b/include/toml++/impl/header_end.h
@@ -6,6 +6,8 @@
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;

--- a/include/toml++/impl/header_start.h
+++ b/include/toml++/impl/header_start.h
@@ -5,7 +5,9 @@
 //# }}
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min

--- a/toml.hpp
+++ b/toml.hpp
@@ -1223,7 +1223,9 @@ TOML_DISABLE_WARNINGS;
 TOML_ENABLE_WARNINGS;
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -2129,7 +2131,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -2137,7 +2141,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -2265,7 +2271,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -2273,7 +2281,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -2385,7 +2395,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -2393,7 +2405,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -2725,7 +2739,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -2779,7 +2795,9 @@ TOML_ENABLE_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -3360,7 +3378,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -3374,7 +3394,9 @@ TOML_ENABLE_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -3977,7 +3999,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -3991,7 +4015,9 @@ TOML_ENABLE_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -4496,7 +4522,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -4504,7 +4532,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -5572,7 +5602,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -5580,7 +5612,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -5748,7 +5782,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -5756,7 +5792,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -6839,7 +6877,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -6847,7 +6887,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -7098,7 +7140,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -7113,7 +7157,9 @@ TOML_ENABLE_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -8258,7 +8304,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -8266,7 +8314,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -8446,7 +8496,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -8454,7 +8506,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -8648,7 +8702,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -8668,7 +8724,9 @@ TOML_ENABLE_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -8770,7 +8828,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -8782,7 +8842,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9117,7 +9179,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9129,7 +9193,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9232,7 +9298,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9244,7 +9312,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9428,7 +9498,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9440,7 +9512,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9529,7 +9603,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9541,7 +9617,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9615,7 +9693,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9627,7 +9707,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9706,7 +9788,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9744,7 +9828,9 @@ extern "C" __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int 
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -9811,7 +9897,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -9833,7 +9921,9 @@ TOML_DISABLE_WARNINGS;
 TOML_ENABLE_WARNINGS;
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -10298,7 +10388,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -10306,7 +10398,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -10435,7 +10529,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -10450,7 +10546,9 @@ TOML_DISABLE_WARNINGS;
 TOML_ENABLE_WARNINGS;
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -10724,7 +10822,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -10738,7 +10838,9 @@ TOML_DISABLE_WARNINGS;
 TOML_ENABLE_WARNINGS;
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -11222,7 +11324,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -11230,7 +11334,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -11605,7 +11711,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -11613,7 +11721,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -11923,7 +12033,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -11962,7 +12074,9 @@ TOML_ENABLE_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -12014,7 +12128,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -12037,7 +12153,9 @@ TOML_DISABLE_WARNINGS;
 TOML_ENABLE_WARNINGS;
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -15911,7 +16029,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -15923,7 +16043,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -16421,7 +16543,9 @@ TOML_IMPL_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -16433,7 +16557,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -16825,7 +16951,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -16837,7 +16965,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -16946,7 +17076,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 
@@ -16958,7 +17090,9 @@ TOML_POP_WARNINGS;
 
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
+#ifndef __clang__
 #pragma inline_recursion(on)
+#endif
 #pragma push_macro("min")
 #pragma push_macro("max")
 #undef min
@@ -17111,7 +17245,9 @@ TOML_NAMESPACE_END;
 #ifdef _MSC_VER
 #pragma pop_macro("min")
 #pragma pop_macro("max")
+#ifndef __clang__
 #pragma inline_recursion(off)
+#endif
 #endif
 TOML_POP_WARNINGS;
 


### PR DESCRIPTION
**What does this change do?**
checks if using clang under `header_start.h` and `header_end.h`



**Is it related to an exisiting bug report or feature request?**
Fixes #191 

**Pre-merge checklist**
<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->
- [X] I've read [CONTRIBUTING.md]
- [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [ ] I've added new test cases to verify my change
- [X] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [ ] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 6 or higher
    - [ ] GCC 7 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)



[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md