### PR TITLE
Fix 32-bit ABI bugs of android

### DIFF
--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -23,6 +23,12 @@
 #include "unicode.hpp"
 TOML_DISABLE_WARNINGS;
 #include <istream>
+
+#if defined(__ANDROID_API__) && __ANDROID_API__ < 24
+    // Cf. https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and
+    #define ftello ftell
+    #define fseeko fseek
+#endif
 #include <fstream>
 #if TOML_INT_CHARCONV || TOML_FLOAT_CHARCONV
 #include <charconv>


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->

**What does this change do?**
Fixes #204, fix 32-bit ABI bugs of android: https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md#32_bit-and

The description of this bug:

> Android does not require the _LARGEFILE_SOURCE macro to be used to make fseeko and ftello available. Instead they're always available from API level 24 where they were introduced, and never available before then.

The related error message:
```
[1/3] /android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ -Isrc/libtomlplusplus.a.p -Isrc -I../src/v3.3.0-055894c820.clean/src -Iinclude -I../src/v3.3.0-055894c820.clean/include -I/mnt/vcpkg-ci/installed/arm-neon-android/include -fvisibility=hidden -fcolor-diagnostics -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++17 -O0 -g --target=armv7-none-linux-androideabi21 -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security -frtti -fexceptions -fPIC --sysroot=/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fno-limit-debug-info -fPIC -ferror-limit=5 -Wno-unused-command-line-argument -Wno-reserved-macro-identifier -fchar8_t -D_HAS_EXCEPTIONS=1 -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-padded -Wno-float-equal -DTOML_HEADER_ONLY=0 -MD -MQ src/libtomlplusplus.a.p/toml.cpp.o -MF src/libtomlplusplus.a.p/toml.cpp.o.d -o src/libtomlplusplus.a.p/toml.cpp.o -c ../src/v3.3.0-055894c820.clean/src/toml.cpp
FAILED: src/libtomlplusplus.a.p/toml.cpp.o 
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ -Isrc/libtomlplusplus.a.p -Isrc -I../src/v3.3.0-055894c820.clean/src -Iinclude -I../src/v3.3.0-055894c820.clean/include -I/mnt/vcpkg-ci/installed/arm-neon-android/include -fvisibility=hidden -fcolor-diagnostics -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++17 -O0 -g --target=armv7-none-linux-androideabi21 -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security -frtti -fexceptions -fPIC --sysroot=/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -fno-limit-debug-info -fPIC -ferror-limit=5 -Wno-unused-command-line-argument -Wno-reserved-macro-identifier -fchar8_t -D_HAS_EXCEPTIONS=1 -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-documentation-unknown-command -Wno-switch-enum -Wno-covered-switch-default -Wno-padded -Wno-float-equal -DTOML_HEADER_ONLY=0 -MD -MQ src/libtomlplusplus.a.p/toml.cpp.o -MF src/libtomlplusplus.a.p/toml.cpp.o.d -o src/libtomlplusplus.a.p/toml.cpp.o -c ../src/v3.3.0-055894c820.clean/src/toml.cpp
In file included from ../src/v3.3.0-055894c820.clean/src/toml.cpp:13:
In file included from ../src/v3.3.0-055894c820.clean/include/toml++/toml.h:69:
In file included from ../src/v3.3.0-055894c820.clean/include/toml++/impl/parser.inl:26:
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/fstream:952:20: error: use of undeclared identifier 'ftello'; did you mean 'ftell'?
    pos_type __r = ftello(__file_);
                   ^
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/cstdio:141:9: note: 'ftell' declared here
using ::ftell;
        ^
In file included from ../src/v3.3.0-055894c820.clean/src/toml.cpp:13:
In file included from ../src/v3.3.0-055894c820.clean/include/toml++/toml.h:69:
In file included from ../src/v3.3.0-055894c820.clean/include/toml++/impl/parser.inl:26:
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/fstream:950:9: error: use of undeclared identifier 'fseeko'
    if (fseeko(__file_, __width > 0 ? __width * __off : 0, __whence))
        ^
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/fstream:213:5: note: in instantiation of member function 'std::basic_filebuf<char>::seekoff' requested here
    basic_filebuf();
    ^
/android-ndk-r25c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/fstream:1142:5: note: in instantiation of member function 'std::basic_filebuf<char>::basic_filebuf' requested here
    basic_ifstream();
```
<!--
    Changes all Foos to Bars.
--->

**Is it related to an exisiting bug report or feature request?**

<!--
    Fixes #204.
--->

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] ~~I've added new test cases to verify my change~~
-   [ ] ~~I've regenerated toml.hpp ([how-to])~~
-   [ ] ~~I've updated any affected documentation~~
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] ~~Clang 8 or higher~~
    -   [x] GCC 8 or higher
    -   [ ] ~~MSVC 19.20 (Visual Studio 2019) or higher~~
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
