### PR TITLE
Resolved bug in kMaxValue in SerializationTest for toml_fuzzer

### DIFF
--- a/fuzzing/toml_fuzzer.cpp
+++ b/fuzzing/toml_fuzzer.cpp
@@ -9,7 +9,7 @@ enum class SerializationTest
     JSON,
     YAML,
     TOML,
-    kMaxValue = YAML
+    kMaxValue = TOML
 };
 
 extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data, const std::size_t size)


### PR DESCRIPTION

**What does this change do?**

Fixes a super simple logic msitake in the harness, where the kMaxValue was set to 1 less than the true max- preventing one branch of the switch from ever being exercised. 

**Is it related to an exisiting bug report or feature request?**
No

**Pre-merge checklist**


-   [X] I've read [CONTRIBUTING.md]
-   [ ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [X] I've rebuilt and run the tests with at least one of:
    -   [X] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [X] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
