### PR TITLE
fix: uses tbl variable name rather than arr in table.get documentation

### DIFF
--- a/include/toml++/impl/table.hpp
+++ b/include/toml++/impl/table.hpp
@@ -605,10 +605,10 @@ TOML_NAMESPACE_START
 		///		{ "a", 42, },
 		///		{ "b", "is the meaning of life, apparently." }
 		///	};
-		///	std::cout << R"(node ["a"] exists: )"sv << !!arr.get("a") << "\n";
-		///	std::cout << R"(node ["b"] exists: )"sv << !!arr.get("b") << "\n";
-		///	std::cout << R"(node ["c"] exists: )"sv << !!arr.get("c") << "\n";
-		/// if (auto val = arr.get("a"))
+		///	std::cout << R"(node ["a"] exists: )"sv << !!tbl.get("a") << "\n";
+		///	std::cout << R"(node ["b"] exists: )"sv << !!tbl.get("b") << "\n";
+		///	std::cout << R"(node ["c"] exists: )"sv << !!tbl.get("c") << "\n";
+		/// if (auto val = tbl.get("a"))
 		///		std::cout << R"(node ["a"] was an )"sv << val->type() << "\n";
 		/// \ecpp
 		///


### PR DESCRIPTION
**What does this change do?**

Corrects example in documentation for table.get().

**Is it related to an exisiting bug report or feature request?**

I don't think so.

**Pre-merge checklist**

-   [X] I've read [CONTRIBUTING.md]
-   [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
