### PR TITLE
meson: install header and pkg-config file and in subprojects

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -5,22 +5,18 @@
 
 include_dir = include_directories('.')
 
-if not is_subproject
-	install_subdir('toml++', install_dir: get_option('includedir'))
-endif
+install_subdir('toml++', install_dir: get_option('includedir'))
 
 if not build_lib # header-only mode
 
 	tomlplusplus_dep = declare_dependency(include_directories: include_dir)
 
-	if not is_subproject
-		import('pkgconfig').generate(
-			name: meson.project_name(),
-			description: 'Header-only TOML config file parser and serializer for C++',
-			install_dir: get_option('datadir')/'pkgconfig',
-			url: 'https://marzer.github.io/tomlplusplus'
-		)
-	endif
+	import('pkgconfig').generate(
+		name: meson.project_name(),
+		description: 'Header-only TOML config file parser and serializer for C++',
+		install_dir: get_option('datadir')/'pkgconfig',
+		url: 'https://marzer.github.io/tomlplusplus'
+	)
 
 	# cmake
 	if get_option('generate_cmake_config') and not is_subproject and not is_devel

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,7 +32,7 @@ tomlplusplus_lib = library(
 	cpp_args: lib_internal_args,
 	gnu_symbol_visibility: get_option('default_library') == 'static' ? '' : 'hidden',
 	include_directories: include_dir,
-	install: not is_subproject,
+	install: true,
 	version: meson.project_version(),
 	override_options: global_overrides
 )
@@ -43,14 +43,12 @@ tomlplusplus_dep = declare_dependency(
 	link_with: tomlplusplus_lib
 )
 
-if not is_subproject
-	import('pkgconfig').generate(
-		tomlplusplus_lib,
-		description: 'TOML config file parser and serializer for C++',
-		extra_cflags: lib_args,
-		url: 'https://marzer.github.io/tomlplusplus'
-	)
-endif
+import('pkgconfig').generate(
+	tomlplusplus_lib,
+	description: 'TOML config file parser and serializer for C++',
+	extra_cflags: lib_args,
+	url: 'https://marzer.github.io/tomlplusplus'
+)
 
 # cmake
 if get_option('generate_cmake_config') and not is_subproject and not is_devel


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->

**What does this change do?**

Install the headers and the pkg-config file also in Meson subprojects. The reasoning behind this is that if you install a Meson project using TOML++ (potentially into a non-standard location like `/opt/project`), and also create a pkg-config file for your project, TOML++ might get added as public or private dependency. In that case, the header (and pkg-config file) should be installed.

<!--
    Changes all Foos to Bars.
--->

**Is it related to an exisiting bug report or feature request?**

No

<!--
    Fixes #69.
--->

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] ~I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
