### PR TITLE
let `print_to_stream` also print the end of a source region

### DIFF
--- a/include/toml++/impl/print_to_stream.inl
+++ b/include/toml++/impl/print_to_stream.inl
@@ -419,8 +419,11 @@ TOML_IMPL_NAMESPACE_START
 	void TOML_CALLCONV print_to_stream(std::ostream & stream, const source_region& val)
 	{
 		print_to_stream(stream, val.begin);
-		print_to_stream(stream, " to "sv);
-		print_to_stream(stream, val.end);
+		if (val.begin != val.end)
+		{
+			print_to_stream(stream, " to "sv);
+			print_to_stream(stream, val.end);
+		}
 		if (val.path)
 		{
 			print_to_stream(stream, " of '"sv);

--- a/include/toml++/impl/print_to_stream.inl
+++ b/include/toml++/impl/print_to_stream.inl
@@ -419,6 +419,8 @@ TOML_IMPL_NAMESPACE_START
 	void TOML_CALLCONV print_to_stream(std::ostream & stream, const source_region& val)
 	{
 		print_to_stream(stream, val.begin);
+		print_to_stream(stream, " to "sv);
+		print_to_stream(stream, val.end);
 		if (val.path)
 		{
 			print_to_stream(stream, " of '"sv);

--- a/toml.hpp
+++ b/toml.hpp
@@ -10694,6 +10694,8 @@ TOML_IMPL_NAMESPACE_START
 	void TOML_CALLCONV print_to_stream(std::ostream & stream, const source_region& val)
 	{
 		print_to_stream(stream, val.begin);
+		print_to_stream(stream, " to "sv);
+		print_to_stream(stream, val.end);
 		if (val.path)
 		{
 			print_to_stream(stream, " of '"sv);

--- a/toml.hpp
+++ b/toml.hpp
@@ -10694,8 +10694,11 @@ TOML_IMPL_NAMESPACE_START
 	void TOML_CALLCONV print_to_stream(std::ostream & stream, const source_region& val)
 	{
 		print_to_stream(stream, val.begin);
-		print_to_stream(stream, " to "sv);
-		print_to_stream(stream, val.end);
+		if (val.begin != val.end)
+		{
+			print_to_stream(stream, " to "sv);
+			print_to_stream(stream, val.end);
+		}
 		if (val.path)
 		{
 			print_to_stream(stream, " of '"sv);


### PR DESCRIPTION
With this commit, `std::cout << node.source()` should print both the begin and the end of the source region.

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
