### PR TITLE
add TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA workaround MSVC error C2057

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@levicki](https://github.com/levicki)** - Helped design some new features
 -   **[@moorereason](https://github.com/moorereason)** - Reported a whole bunch of bugs
 -   **[@mosra](https://github.com/mosra)** - Created the awesome [m.css] used to generate the API docs
+-   **[@N-Dekker](https://github.com/N-Dekker)** - Added a workaround for the legacy lambda processor of MSVC 2019/2022
 -   **[@ned14](https://github.com/ned14)** - Reported a bunch of bugs and helped design some new features
 -   **[@okureta](https://github.com/okureta)** - Reported a bug
 -   **[@prince-chrismc](https://github.com/prince-chrismc)** - Added toml++ to ConanCenter, and fixed some typos

--- a/include/toml++/impl/array.hpp
+++ b/include/toml++/impl/array.hpp
@@ -951,7 +951,10 @@ TOML_NAMESPACE_START
 					static_cast<node_ref>(static_cast<Array&&>(arr)[i])
 						.visit(
 							[&]([[maybe_unused]] auto&& elem) //
+// Define this macro as a workaround to compile errors caused by a bug in MSVC's "legacy lambda processor".
+#if !TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
 							noexcept(for_each_is_nothrow_one<Func&&, Array&&, decltype(elem)>::value)
+#endif
 							{
 								using elem_ref = for_each_elem_ref<decltype(elem), Array&&>;
 								static_assert(std::is_reference_v<elem_ref>);

--- a/include/toml++/impl/preprocessor.hpp
+++ b/include/toml++/impl/preprocessor.hpp
@@ -1241,6 +1241,17 @@ TOML_ENABLE_WARNINGS;
 /// \detail Defaults to `0`.
 //# }}
 
+#ifndef TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
+#define TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA 0
+#endif
+//# {{
+/// \def TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
+/// \brief Disable using noexcept(<condition>) in lambda definitions within the toml++ library implementation.
+/// \detail This macro offers a workaround to a bug in the old "legacy lambda processor" of Visual C++, which
+/// caused compile errors like "error C2057: expected constant expression", when it encountered such lambda's.
+/// These compile errors were reported by Kevin Dick, Jan 19, 2024, at https://github.com/marzer/tomlplusplus/issues/219
+//# }}
+
 /// @}
 //#====================================================================================================================
 //# CHARCONV SUPPORT

--- a/include/toml++/impl/table.hpp
+++ b/include/toml++/impl/table.hpp
@@ -930,7 +930,10 @@ TOML_NAMESPACE_START
 					static_cast<node_ref>(*kvp.second)
 						.visit(
 							[&]([[maybe_unused]] auto&& v) //
+// Define this macro as a workaround to compile errors caused by a bug in MSVC's "legacy lambda processor".
+#if !TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
 							noexcept(for_each_is_nothrow_one<Func&&, Table&&, decltype(v)>::value)
+#endif
 							{
 								using value_ref = for_each_value_ref<decltype(v), Table&&>;
 								static_assert(std::is_reference_v<value_ref>);

--- a/toml.hpp
+++ b/toml.hpp
@@ -1133,6 +1133,10 @@ TOML_ENABLE_WARNINGS;
 #define TOML_ENABLE_FLOAT16 0
 #endif
 
+#ifndef TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
+#define TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA 0
+#endif
+
 #if !defined(TOML_FLOAT_CHARCONV) && (TOML_GCC || TOML_CLANG || (TOML_ICC && !TOML_ICC_CL))
 // not supported by any version of GCC or Clang as of 26/11/2020
 // not supported by any version of ICC on Linux as of 11/01/2021
@@ -6799,7 +6803,10 @@ TOML_NAMESPACE_START
 					static_cast<node_ref>(static_cast<Array&&>(arr)[i])
 						.visit(
 							[&]([[maybe_unused]] auto&& elem) //
+// Define this macro as a workaround to compile errors caused by a bug in MSVC's "legacy lambda processor".
+#if !TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
 							noexcept(for_each_is_nothrow_one<Func&&, Array&&, decltype(elem)>::value)
+#endif
 							{
 								using elem_ref = for_each_elem_ref<decltype(elem), Array&&>;
 								static_assert(std::is_reference_v<elem_ref>);
@@ -8161,7 +8168,10 @@ TOML_NAMESPACE_START
 					static_cast<node_ref>(*kvp.second)
 						.visit(
 							[&]([[maybe_unused]] auto&& v) //
+// Define this macro as a workaround to compile errors caused by a bug in MSVC's "legacy lambda processor".
+#if !TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
 							noexcept(for_each_is_nothrow_one<Func&&, Table&&, decltype(v)>::value)
+#endif
 							{
 								using value_ref = for_each_value_ref<decltype(v), Table&&>;
 								static_assert(std::is_reference_v<value_ref>);


### PR DESCRIPTION
Offered a workaround to compile errors like "error C2057: expected constant expression", when using the "legacy lambda processor" of Visual C++. Such compile errors were reported by Kevin Dick, Jan 19, 2024, at issue #219


-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
