### PR TITLE
add unit test for pull request #244 (print end of source region)

### DIFF
--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -444,4 +444,11 @@ b = []
 								   CHECK(ss.str() == output);
 							   });
 	}
+
+	SECTION("tomlplusplus/pull/244") // https://github.com/marzer/tomlplusplus/pull/244
+	{
+		std::ostringstream oss;
+		oss << toml::source_region{ { 1, 2 }, { 3, 4 }, nullptr };
+		CHECK(oss.str() == "line 1, column 2 to line 3, column 4");
+	}
 }


### PR DESCRIPTION
Tested commit 1fdd67ce5aab68ab056b9caad4b94ea665753040, "let `print_to_stream` also print the end of a source region (#244)"

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [x] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
