### PR TITLE
docs: Fix some contributors profile link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@rbrugo](https://github.com/rbrugo)** - Helped design a new feature
 -   **[@Reedbeta](https://github.com/Reedbeta)** - Fixed a bug and added additional Visual Studio debugger native visualizers
 -   **[@Ryan-rsm-McKenzie](https://github.com/Ryan-rsm-McKenzie)** - Add natvis file to cmake install script
--   **[@Scrumplex][https://github.com/Scrumplex)** - Tweaked the build scripts
+-   **[@Scrumplex](https://github.com/Scrumplex)** - Tweaked the build scripts
 -   **[@shdnx](https://github.com/shdnx)** - Fixed a bug on GCC 8.2.0 and some meson config issues
 -   **[@sneves](https://github.com/sneves)** - Helped fix a number of parser bugs
 -   **[@sobczyk](https://github.com/sobczyk)** - Reported some bugs
@@ -307,7 +307,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@ximion](https://github.com/ximion)** - Added support for installation with meson
 -   **[@a-is](https://github.com/a-is)** - Fixed a bug
 -   **[@capuanob](https://github.com/capuanob)** - Integrated this project into OSSFuzz
--   **[@tyler92]** - Fixed stack overflow that occurred during fuzzing tests
+-   **[@tyler92](https://github.com/tyler92)** - Fixed stack overflow that occurred during fuzzing tests
 <br>
 
 ## Contact


### PR DESCRIPTION
**What does this change do?**

Fix some contributors profile link in the README

**Is it related to an exisiting bug report or feature request?**

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
