### PR TITLE
test MSVC default conformance mode, using its legacy lambda processor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,9 @@ jobs:
                 type:
                     - "debug"
                     - "release"
+                permissive:
+                    - false
+                    - true
 
         runs-on: windows-2022
 
@@ -130,7 +133,7 @@ jobs:
             - uses: ilammy/msvc-dev-cmd@v1
 
             - name: Configure Meson
-              run: meson setup build --vsenv --buildtype=${{ matrix.type }} -Ddevel=true -Db_lto=false
+              run: meson setup build --vsenv --buildtype=${{ matrix.type }} -Ddevel=true -Db_lto=false -Dpermissive=${{ matrix.permissive }}
 
             - name: Build
               run: meson compile -C build

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ is_devel = get_option('devel')
 is_debug = get_option('debug')
 is_release = not is_debug
 is_pedantic = get_option('pedantic') or is_devel
+is_permissive = get_option('permissive')
 is_windows = host_machine.system() == 'windows'
 is_x64 = host_machine.cpu_family() == 'x86_64'
 is_subproject = meson.is_subproject()
@@ -75,7 +76,6 @@ global_args = cpp.get_supported_arguments(
 	'/Gy', # function-level linking
 	'/GF', # string pooling
 	'/openmp-',
-	'/permissive-',
 	'/utf-8',
 	'/volatile:iso',
 	'/Zc:__cplusplus',
@@ -87,6 +87,11 @@ if has_exceptions
 	global_args += cpp.get_supported_arguments('/Zc:throwingNew', '-D_HAS_EXCEPTIONS=1')
 else
 	global_args += cpp.get_supported_arguments('-D_HAS_EXCEPTIONS=0')
+endif
+if is_permissive
+	global_args += cpp.get_supported_arguments('/permissive', '-DTOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA=1')
+else
+	global_args += cpp.get_supported_arguments('/permissive-')
 endif
 if is_pedantic
 	global_args += cpp.get_supported_arguments(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,7 @@ option('build_examples',		type: 'boolean', value: false,	description: 'Build the
 option('build_tests',			type: 'boolean', value: false,	description: 'Build tests (default: false) (implied by devel)')
 option('build_tt',				type: 'boolean', value: false,	description: 'Enable to build the toml-test encoder and decoder. (default: false) (implied by devel) (disabled by unreleased_features)')
 option('pedantic',				type: 'boolean', value: false,	description: 'Enable as many compiler warnings as possible (default: false) (implied by devel)')
+option('permissive',			type: 'boolean', value: false,	description: 'Add compiler option /permissive (default: false, which implies /permissive-) (only relevant for MSVC)')
 option('time_trace',			type: 'boolean', value: false,	description: 'Enable the -ftime-trace option (Clang only)')
 option('unreleased_features',	type: 'boolean', value: false,	description: 'Enable TOML_UNRELEASED_FEATURES=1 (default: false) (only relevant when compiling the library)')
 

--- a/tests/vs/test_release_x64_legacy_lambda.vcxproj
+++ b/tests/vs/test_release_x64_legacy_lambda.vcxproj
@@ -1,0 +1,128 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<ItemGroup Label="ProjectConfigurations">
+		<ProjectConfiguration Include="Release|x64">
+			<Configuration>Release</Configuration>
+			<Platform>x64</Platform>
+		</ProjectConfiguration>
+	</ItemGroup>
+	<PropertyGroup Label="Globals">
+		<VCProjectVersion>16.0</VCProjectVersion>
+		<ProjectGuid>{D318404F-B9AB-4CFB-AEF1-92CE23369837}</ProjectGuid>
+		<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+		<PreferredToolArchitecture>x64</PreferredToolArchitecture>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>true</UseDebugLibraries>
+		<PlatformToolset>v143</PlatformToolset>
+		<CharacterSet>MultiByte</CharacterSet>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+		<ConfigurationType>Application</ConfigurationType>
+		<UseDebugLibraries>false</UseDebugLibraries>
+		<PlatformToolset>v143</PlatformToolset>
+		<WholeProgramOptimization>true</WholeProgramOptimization>
+		<CharacterSet>MultiByte</CharacterSet>
+	</PropertyGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+	<ImportGroup Label="PropertySheets">
+		<Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props"
+			Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+	</ImportGroup>
+	<Import Project="../../toml++.props" />
+	<ItemDefinitionGroup>
+		<ClCompile>
+			<AdditionalIncludeDirectories>..\tests;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+			<ExceptionHandling>Sync</ExceptionHandling>
+			<PrecompiledHeader>Use</PrecompiledHeader>
+			<PrecompiledHeaderFile>tests.hpp</PrecompiledHeaderFile>
+			<PreprocessorDefinitions>TOML_ENABLE_UNRELEASED_FEATURES=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<PreprocessorDefinitions>LEAK_TESTS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<PreprocessorDefinitions Condition="'%(ExceptionHandling)'=='false'">_HAS_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<PreprocessorDefinitions Condition="'%(ExceptionHandling)'=='false'">SHOULD_HAVE_EXCEPTIONS=0;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<PreprocessorDefinitions Condition="'%(ExceptionHandling)'!='false'">SHOULD_HAVE_EXCEPTIONS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+			<LanguageStandard>stdcpp17</LanguageStandard>
+			<MultiProcessorCompilation>true</MultiProcessorCompilation>
+			<WarningLevel>EnableAllWarnings</WarningLevel>
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4127</DisableSpecificWarnings> <!-- conditional expr is constant -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4324</DisableSpecificWarnings> <!-- structure was padded due to alignment specifier -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4464</DisableSpecificWarnings> <!-- relative include path contains '..' -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4505</DisableSpecificWarnings> <!-- unreferenced local function removed -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4514</DisableSpecificWarnings> <!-- unreferenced inline function has been removed -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4577</DisableSpecificWarnings> <!-- 'noexcept' used with no exception handling mode specified -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4582</DisableSpecificWarnings> <!-- constructor is not implicitly called -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4623</DisableSpecificWarnings> <!-- default constructor was implicitly defined as deleted -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4625</DisableSpecificWarnings> <!-- copy constructor was implicitly defined as deleted -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4626</DisableSpecificWarnings> <!-- assignment operator was implicitly defined as deleted -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4710</DisableSpecificWarnings> <!-- function not inlined -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4711</DisableSpecificWarnings> <!-- function selected for automatic expansion -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4738</DisableSpecificWarnings> <!-- storing 32-bit float result in memory -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4820</DisableSpecificWarnings> <!-- N bytes padding added -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4866</DisableSpecificWarnings> <!-- compiler may not enforce ltr eval in operator[] -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4868</DisableSpecificWarnings> <!-- compiler may not enforce ltr eval in initializer list -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);4946</DisableSpecificWarnings> <!-- reinterpret_cast used between related classes -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);5026</DisableSpecificWarnings> <!-- move constructor was implicitly defined as deleted -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);5027</DisableSpecificWarnings> <!-- move assignment operator was implicitly defined as deleted -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);5039</DisableSpecificWarnings> <!-- potentially throwing function passed to 'extern "C"' -->
+			<DisableSpecificWarnings>%(DisableSpecificWarnings);5045</DisableSpecificWarnings> <!-- Compiler will insert Spectre mitigation -->
+			<ConformanceMode>Default</ConformanceMode> <!-- Default Conformance Mode implies using the legacy lambda processor -->
+		</ClCompile>
+	</ItemDefinitionGroup>
+	<PropertyGroup>
+		<LocalDebuggerWorkingDirectory>$(ProjectDir)..\</LocalDebuggerWorkingDirectory>
+	</PropertyGroup>
+	<ItemGroup>
+		<ClCompile Include="..\at_path.cpp" />
+		<ClCompile Include="..\path.cpp" />
+		<ClCompile Include="..\conformance_burntsushi_invalid.cpp" />
+		<ClCompile Include="..\conformance_burntsushi_valid.cpp" />
+		<ClCompile Include="..\conformance_iarna_invalid.cpp" />
+		<ClCompile Include="..\conformance_iarna_valid.cpp" />
+		<ClCompile Include="..\for_each.cpp" />
+		<ClCompile Include="..\formatters.cpp" />
+		<ClCompile Include="..\impl_toml.cpp">
+			<PrecompiledHeader>NotUsing</PrecompiledHeader>
+		</ClCompile>
+		<ClCompile Include="..\main.cpp">
+			<PrecompiledHeader>NotUsing</PrecompiledHeader>
+		</ClCompile>
+		<ClCompile Include="..\manipulating_arrays.cpp" />
+		<ClCompile Include="..\manipulating_tables.cpp" />
+		<ClCompile Include="..\manipulating_parse_result.cpp" />
+		<ClCompile Include="..\manipulating_values.cpp" />
+		<ClCompile Include="..\parsing_arrays.cpp" />
+		<ClCompile Include="..\parsing_booleans.cpp" />
+		<ClCompile Include="..\parsing_comments.cpp" />
+		<ClCompile Include="..\parsing_dates_and_times.cpp" />
+		<ClCompile Include="..\parsing_floats.cpp" />
+		<ClCompile Include="..\parsing_integers.cpp" />
+		<ClCompile Include="..\parsing_key_value_pairs.cpp" />
+		<ClCompile Include="..\parsing_spec_example.cpp" />
+		<ClCompile Include="..\parsing_strings.cpp" />
+		<ClCompile Include="..\parsing_tables.cpp" />
+		<ClCompile Include="..\tests.cpp">
+			<PrecompiledHeader>Create</PrecompiledHeader>
+		</ClCompile>
+		<ClCompile Include="..\user_feedback.cpp" />
+		<ClCompile Include="..\using_iterators.cpp" />
+		<ClCompile Include="..\visit.cpp" />
+		<ClCompile Include="..\windows_compat.cpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<Natvis Include="..\..\toml++.natvis" />
+	</ItemGroup>
+	<ItemGroup>
+		<ClInclude Include="..\leakproof.hpp" />
+		<ClInclude Include="..\lib_catch2.hpp" />
+		<ClInclude Include="..\lib_tloptional.hpp" />
+		<ClInclude Include="..\settings.hpp" />
+		<ClInclude Include="..\tests.hpp" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="..\cpp.hint" />
+		<None Include="..\meson.build" />
+	</ItemGroup>
+	<Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/toml++.sln
+++ b/toml++.sln
@@ -59,6 +59,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_release_x64_cpplatest_
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_release_x64_cpplatest_unrel", "tests\vs\test_release_x64_cpplatest_unrel.vcxproj", "{74813AFD-DB22-52FA-9108-0BADD4B0E161}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_release_x64_legacy_lambda", "tests\vs\test_release_x64_legacy_lambda.vcxproj", "{D318404F-B9AB-4CFB-AEF1-92CE23369837}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_release_x64_noexcept", "tests\vs\test_release_x64_noexcept.vcxproj", "{B1B28D93-892C-59BF-9C6F-D813EC6438A0}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_release_x64_noexcept_unrel", "tests\vs\test_release_x64_noexcept_unrel.vcxproj", "{6C3EA8CD-33CC-5775-ACC4-631FF5FE1E2C}"
@@ -265,6 +267,10 @@ Global
 		{E467EB97-B066-4D38-B3DB-60961E3F96A1}.Debug|x64.Build.0 = Debug|x64
 		{E467EB97-B066-4D38-B3DB-60961E3F96A1}.Release|x64.ActiveCfg = Release|x64
 		{E467EB97-B066-4D38-B3DB-60961E3F96A1}.Release|x64.Build.0 = Release|x64
+		{D318404F-B9AB-4CFB-AEF1-92CE23369837}.Debug|x64.ActiveCfg = Release|x64
+		{D318404F-B9AB-4CFB-AEF1-92CE23369837}.Debug|x64.Build.0 = Release|x64
+		{D318404F-B9AB-4CFB-AEF1-92CE23369837}.Release|x64.ActiveCfg = Release|x64
+		{D318404F-B9AB-4CFB-AEF1-92CE23369837}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -311,6 +317,7 @@ Global
 		{8F673261-5DFE-4B67-937A-61FC3F0082A2} = {5DE43BF4-4EDD-4A7A-A422-764415BB3224}
 		{723FC4CA-0E24-4956-8FDC-E537EA3847AA} = {4E25CF88-D7D8-4A9C-A52E-0D78281E82EC}
 		{E467EB97-B066-4D38-B3DB-60961E3F96A1} = {412816A5-9D22-4A30-BCDF-ABFB54BB3735}
+		{D318404F-B9AB-4CFB-AEF1-92CE23369837} = {4E25CF88-D7D8-4A9C-A52E-0D78281E82EC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0926DDCC-88CD-4839-A82D-D9B99E02A0B1}


### PR DESCRIPTION
The added "test_release_x64_legacy_lambda.vcxproj" is basically just a copy of "test_release_x64.vcxproj", but it has an extra property `ConformanceMode`, set to `Default`. Which triggers MSVC to use its "legacy lambda processor".

With such a configuration, the user may need to define `TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA`.

Update, March 4, 2025: The pull request now also adds `/permissive` builds to the CI, using `TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA` to prevent compile errors.

Follow-up to commit cbc00d6766f14bcd2b3e72de2a3c369a0d48b98a "add TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA workaround MSVC error C2057 (#247)"


-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [x] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
