### PR TITLE
add `get_line(doc, line_num)` utility

### DIFF
--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -451,4 +451,36 @@ b = []
 		oss << toml::source_region{ { 1, 2 }, { 3, 4 }, nullptr };
 		CHECK(oss.str() == "line 1, column 2 to line 3, column 4");
 	}
+
+	SECTION("tomlplusplus/issues/254") // https://github.com/marzer/tomlplusplus/issues/254
+	{
+		for (const toml::source_index line_num: { 0u, 1u, 2u })
+		{
+			CHECK(toml::get_line(""sv, line_num) == std::string_view{});
+		}
+
+		for (const auto input : {
+				 "# \r (embedded carriage return)"sv,
+				 "# \r (embedded carriage return)\n"sv,
+				 "# \r (embedded carriage return)\r\n"sv,
+			 })
+		{
+			CHECK(toml::get_line(input, 0) == std::string_view{});
+			CHECK(toml::get_line(input, 1) == "# \r (embedded carriage return)"sv);
+			CHECK(toml::get_line(input, 2) == std::string_view{});
+		}
+
+		for (const auto input : {
+				 "alpha = 1\nbeta = 2\n # last line # "sv,
+				 "alpha = 1\nbeta = 2\n # last line # \n"sv,
+				 "alpha = 1\r\nbeta = 2\r\n # last line # \r\n"sv,
+			 })
+		{
+			CHECK(toml::get_line(input, 0) == std::string_view{});
+			CHECK(toml::get_line(input, 1) == "alpha = 1"sv);
+			CHECK(toml::get_line(input, 2) == "beta = 2"sv);
+			CHECK(toml::get_line(input, 3) == " # last line # "sv);
+			CHECK(toml::get_line(input, 4) == std::string_view{});
+		}
+	}
 }

--- a/toml.hpp
+++ b/toml.hpp
@@ -2634,6 +2634,60 @@ TOML_NAMESPACE_START
 			return lhs;
 		}
 	};
+
+	TOML_NODISCARD
+	inline std::string_view get_line(std::string_view doc, source_index line_num) noexcept
+	{
+		if (line_num == 0)
+		{
+			// Invalid line number. Should be greater than zero.
+			return {};
+		}
+
+		// The position of the first character of the specified line.
+		const auto begin_of_line = [doc, line_num]() -> std::size_t
+		{
+			if (line_num == 1)
+			{
+				return 0;
+			}
+
+			const auto num_chars_of_doc = doc.size();
+			std::size_t current_line_num{ 1 };
+
+			for (std::size_t i{}; i < num_chars_of_doc; ++i)
+			{
+				if (doc[i] == '\n')
+				{
+					++current_line_num;
+
+					if (current_line_num == line_num)
+					{
+						return i + 1;
+					}
+				}
+			}
+			return std::string_view::npos;
+		}();
+
+		if (begin_of_line >= doc.size())
+		{
+			return {};
+		}
+
+		if (const auto end_of_line = doc.find('\n', begin_of_line); end_of_line != std::string_view::npos)
+		{
+			const auto num_chars_of_line = end_of_line - begin_of_line;
+
+			// Trim an optional trailing carriage return.
+			return doc.substr(begin_of_line,
+							  ((num_chars_of_line > 0) && (doc[end_of_line - 1] == '\r')) ? num_chars_of_line - 1
+																						  : num_chars_of_line);
+		}
+
+		// Return the last line. Apparently this doc has no trailing line break character at the end.
+		return doc.substr(begin_of_line);
+	}
 }
 TOML_NAMESPACE_END;
 


### PR DESCRIPTION
**What does this change do?**

This pull request adds a utility function, `get_line(doc, line_num)`, which returns the specified line as a `string_view`.

**Is it related to an existing bug report or feature request?**

This feature was discussed at issue #254.

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [x] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
