### PR TITLE
declare `toml::get_line(std::string_view, source_index)` constexpr

### DIFF
--- a/include/toml++/impl/source_region.hpp
+++ b/include/toml++/impl/source_region.hpp
@@ -237,7 +237,7 @@ TOML_NAMESPACE_START
 	/// \returns	The specified line, excluding any possible trailing carriage return or line feed character.
 	/// \remarks Returns an empty string_view when there is no line at the specified line number, in the specified document.
 	TOML_NODISCARD
-	inline std::string_view get_line(std::string_view doc, source_index line_num) noexcept
+	constexpr std::string_view get_line(std::string_view doc, source_index line_num) noexcept
 	{
 		if (line_num == 0)
 		{

--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -454,7 +454,11 @@ b = []
 
 	SECTION("tomlplusplus/issues/254") // https://github.com/marzer/tomlplusplus/issues/254
 	{
-		for (const toml::source_index line_num: { 0u, 1u, 2u })
+		// Check constexpr support.
+		static_assert(toml::get_line(""sv, 1) == std::string_view{});
+		static_assert(toml::get_line("alpha = 1\nbeta = 2\n # last line # "sv, 1) == "alpha = 1"sv);
+
+		for (const toml::source_index line_num : { 0u, 1u, 2u })
 		{
 			CHECK(toml::get_line(""sv, line_num) == std::string_view{});
 		}

--- a/toml.hpp
+++ b/toml.hpp
@@ -2636,7 +2636,7 @@ TOML_NAMESPACE_START
 	};
 
 	TOML_NODISCARD
-	inline std::string_view get_line(std::string_view doc, source_index line_num) noexcept
+	constexpr std::string_view get_line(std::string_view doc, source_index line_num) noexcept
 	{
 		if (line_num == 0)
 		{


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->

**What does this change do?**

This pull request makes `toml::get_line` constexpr.

**Is it related to an exisiting bug report or feature request?**

- It is a follow-up to pull request #255

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [x] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
