### PR TITLE
specify `get_line` behavior on out of range versus empty line

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@levicki](https://github.com/levicki)** - Helped design some new features
 -   **[@moorereason](https://github.com/moorereason)** - Reported a whole bunch of bugs
 -   **[@mosra](https://github.com/mosra)** - Created the awesome [m.css] used to generate the API docs
--   **[@N-Dekker](https://github.com/N-Dekker)** - Added a workaround for the legacy lambda processor of MSVC 2019/2022
+-   **[@N-Dekker](https://github.com/N-Dekker)** - Added a workaround for the legacy lambda processor of MSVC 2019/2022, added `get_line`
 -   **[@ned14](https://github.com/ned14)** - Reported a bunch of bugs and helped design some new features
 -   **[@okureta](https://github.com/okureta)** - Reported a bug
 -   **[@prince-chrismc](https://github.com/prince-chrismc)** - Added toml++ to ConanCenter, and fixed some typos

--- a/include/toml++/impl/source_region.hpp
+++ b/include/toml++/impl/source_region.hpp
@@ -235,7 +235,11 @@ TOML_NAMESPACE_START
 	/// \param 	line_num	The line number (1-based).
 	///
 	/// \returns	The specified line, excluding any possible trailing carriage return or line feed character.
-	/// \remarks Returns an empty string_view when there is no line at the specified line number, in the specified document.
+	/// \remarks	The data pointer of the returned `string_view` will be null when the specified line
+	///				number is out of range (i.e., when the line number is zero, or greater than the
+	///				total number of lines of the specified document). Otherwise, when the line
+	///				number is within the document and the line is empty, the returned `string_view` will
+	///				also be empty, but then its	data pointer will not be null.
 	TOML_NODISCARD
 	constexpr std::string_view get_line(std::string_view doc, source_index line_num) noexcept
 	{

--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -455,12 +455,16 @@ b = []
 	SECTION("tomlplusplus/issues/254") // https://github.com/marzer/tomlplusplus/issues/254
 	{
 		// Check constexpr support.
-		static_assert(toml::get_line(""sv, 1) == std::string_view{});
+		static_assert(toml::get_line(""sv, 1).data() == nullptr);
 		static_assert(toml::get_line("alpha = 1\nbeta = 2\n # last line # "sv, 1) == "alpha = 1"sv);
+
+		constexpr auto expected_empty_line = toml::get_line("# line one\n\n# line three"sv, 2);
+		static_assert(expected_empty_line.empty());
+		static_assert(expected_empty_line.data() != nullptr);
 
 		for (const toml::source_index line_num : { 0u, 1u, 2u })
 		{
-			CHECK(toml::get_line(""sv, line_num) == std::string_view{});
+			CHECK(toml::get_line(""sv, line_num).data() == nullptr);
 		}
 
 		for (const auto input : {
@@ -469,9 +473,9 @@ b = []
 				 "# \r (embedded carriage return)\r\n"sv,
 			 })
 		{
-			CHECK(toml::get_line(input, 0) == std::string_view{});
+			CHECK(toml::get_line(input, 0).data() == nullptr);
 			CHECK(toml::get_line(input, 1) == "# \r (embedded carriage return)"sv);
-			CHECK(toml::get_line(input, 2) == std::string_view{});
+			CHECK(toml::get_line(input, 2).data() == nullptr);
 		}
 
 		for (const auto input : {
@@ -480,11 +484,11 @@ b = []
 				 "alpha = 1\r\nbeta = 2\r\n # last line # \r\n"sv,
 			 })
 		{
-			CHECK(toml::get_line(input, 0) == std::string_view{});
+			CHECK(toml::get_line(input, 0).data() == nullptr);
 			CHECK(toml::get_line(input, 1) == "alpha = 1"sv);
 			CHECK(toml::get_line(input, 2) == "beta = 2"sv);
 			CHECK(toml::get_line(input, 3) == " # last line # "sv);
-			CHECK(toml::get_line(input, 4) == std::string_view{});
+			CHECK(toml::get_line(input, 4).data() == nullptr);
 		}
 	}
 }


### PR DESCRIPTION
**Commit text**

When the specified line is empty, the returned `string_view` will still have a valid (non-null) data pointer. When the line number is out of range, the data pointer will be null.


**What does this change do?**

It documents the return value more specifically, when the specified line number is out of range, and when the line is empty. Allowing users to distinguish between those two cases more easily.

**Is it related to an exisiting bug report or feature request?**
 - It's another follow-up to pull request #255 !

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [x] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
