### PR TITLE
let `toml::get_line` return an _optional_ string_view

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@levicki](https://github.com/levicki)** - Helped design some new features
 -   **[@moorereason](https://github.com/moorereason)** - Reported a whole bunch of bugs
 -   **[@mosra](https://github.com/mosra)** - Created the awesome [m.css] used to generate the API docs
--   **[@N-Dekker](https://github.com/N-Dekker)** - Added a workaround for the legacy lambda processor of MSVC 2019/2022
+-   **[@N-Dekker](https://github.com/N-Dekker)** - Added a workaround for the legacy lambda processor of MSVC 2019/2022, added `get_line`
 -   **[@ned14](https://github.com/ned14)** - Reported a bunch of bugs and helped design some new features
 -   **[@okureta](https://github.com/okureta)** - Reported a bug
 -   **[@prince-chrismc](https://github.com/prince-chrismc)** - Added toml++ to ConanCenter, and fixed some typos

--- a/include/toml++/impl/source_region.hpp
+++ b/include/toml++/impl/source_region.hpp
@@ -224,7 +224,7 @@ TOML_NAMESPACE_START
 	/// auto doc = "alpha = 1\nbeta = 2"sv;
 	/// auto second_line = toml::get_line(doc, 2);
 	///
-	/// std::cout << "The second line says \"" << second_line << "\"\n";
+	/// std::cout << "The second line says \"" << second_line.value() << "\"\n";
 	/// \ecpp
 	///
 	/// \out
@@ -235,9 +235,10 @@ TOML_NAMESPACE_START
 	/// \param 	line_num	The line number (1-based).
 	///
 	/// \returns	The specified line, excluding any possible trailing carriage return or line feed character.
-	/// \remarks Returns an empty string_view when there is no line at the specified line number, in the specified document.
+	/// \remarks	Returns an empty `optional` when the specified line number is out of range, i.e., when
+	///				the line number is zero or greater than the total number of lines of the specified document.
 	TOML_NODISCARD
-	constexpr std::string_view get_line(std::string_view doc, source_index line_num) noexcept
+	constexpr optional<std::string_view> get_line(std::string_view doc, source_index line_num) noexcept
 	{
 		if (line_num == 0)
 		{

--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -455,12 +455,12 @@ b = []
 	SECTION("tomlplusplus/issues/254") // https://github.com/marzer/tomlplusplus/issues/254
 	{
 		// Check constexpr support.
-		static_assert(toml::get_line(""sv, 1) == std::string_view{});
+		static_assert(!toml::get_line(""sv, 1));
 		static_assert(toml::get_line("alpha = 1\nbeta = 2\n # last line # "sv, 1) == "alpha = 1"sv);
 
 		for (const toml::source_index line_num : { 0u, 1u, 2u })
 		{
-			CHECK(toml::get_line(""sv, line_num) == std::string_view{});
+			CHECK(!toml::get_line(""sv, line_num));
 		}
 
 		for (const auto input : {
@@ -469,22 +469,23 @@ b = []
 				 "# \r (embedded carriage return)\r\n"sv,
 			 })
 		{
-			CHECK(toml::get_line(input, 0) == std::string_view{});
+			CHECK(!toml::get_line(input, 0));
 			CHECK(toml::get_line(input, 1) == "# \r (embedded carriage return)"sv);
-			CHECK(toml::get_line(input, 2) == std::string_view{});
+			CHECK(!toml::get_line(input, 2));
 		}
 
 		for (const auto input : {
-				 "alpha = 1\nbeta = 2\n # last line # "sv,
-				 "alpha = 1\nbeta = 2\n # last line # \n"sv,
-				 "alpha = 1\r\nbeta = 2\r\n # last line # \r\n"sv,
+				 "alpha = 1\nbeta = 2\n\n # last line # "sv,
+				 "alpha = 1\nbeta = 2\n\n # last line # \n"sv,
+				 "alpha = 1\r\nbeta = 2\r\n\r\n # last line # \r\n"sv,
 			 })
 		{
-			CHECK(toml::get_line(input, 0) == std::string_view{});
+			CHECK(!toml::get_line(input, 0));
 			CHECK(toml::get_line(input, 1) == "alpha = 1"sv);
 			CHECK(toml::get_line(input, 2) == "beta = 2"sv);
-			CHECK(toml::get_line(input, 3) == " # last line # "sv);
-			CHECK(toml::get_line(input, 4) == std::string_view{});
+			CHECK(toml::get_line(input, 3) == ""sv);
+			CHECK(toml::get_line(input, 4) == " # last line # "sv);
+			CHECK(!toml::get_line(input, 5));
 		}
 	}
 }

--- a/toml.hpp
+++ b/toml.hpp
@@ -2636,7 +2636,7 @@ TOML_NAMESPACE_START
 	};
 
 	TOML_NODISCARD
-	constexpr std::string_view get_line(std::string_view doc, source_index line_num) noexcept
+	constexpr optional<std::string_view> get_line(std::string_view doc, source_index line_num) noexcept
 	{
 		if (line_num == 0)
 		{


### PR DESCRIPTION
**Commit message**

let `toml::get_line` return an _optional_ string_view

Allows users to detect more easily when the specified line number is out of range.

**What does this change do?**

Changes the return type of `get_line` from `string_view` to `optional<string_view>`.

**Is it related to an exisiting bug report or feature request?**

 - Aims to supersede pull request #257, following Mark's suggestion at https://github.com/marzer/tomlplusplus/pull/257#issuecomment-2685814256

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [x] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
