### PR TITLE
let error_printer example print source line of parse error

### DIFF
--- a/examples/error_printer.cpp
+++ b/examples/error_printer.cpp
@@ -104,6 +104,39 @@ namespace
 
 	inline constexpr auto divider =
 		"################################################################################"sv;
+
+	void print_string(std::string_view str)
+	{
+		for (char c : str)
+		{
+			if (c >= 0 && static_cast<std::size_t>(c) < std::size(toml::impl::control_char_escapes))
+			{
+				std::cout << toml::impl::control_char_escapes[static_cast<std::size_t>(c)];
+			}
+			else
+			{
+				if (c == '\\')
+				{
+					std::cout << '\\';
+				}
+				std::cout << c;
+			}
+		}
+	}
+
+	void print_parse_error(std::string_view doc, const toml::parse_error& err)
+	{
+		std::cout << err;
+
+		auto line_num = err.source().begin.line;
+
+		if (auto line = toml::get_line(doc, line_num))
+		{
+			std::cout << "\nLine "sv << line_num << ": "sv;
+			print_string(*line);
+		}
+		std::cout << "\n\n"sv;
+	}
 }
 
 int main()
@@ -118,11 +151,11 @@ int main()
 		}
 		catch (const toml::parse_error& err)
 		{
-			std::cout << err << "\n\n"sv;
+			print_parse_error(str, err);
 		}
 #else
 		if (auto result = toml::parse(str); !result)
-			std::cout << result.error() << "\n\n"sv;
+			print_parse_error(str, result.error());
 #endif
 	};
 


### PR DESCRIPTION
**What does this change do?**

It aims to demonstrate a typical use case for `toml::get_line`: printing the source line of a parse error.

**Is it related to an exisiting bug report or feature request?**

- Follow-up to pull request #258.

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
