### PR TITLE
add DEL character example `invalid_parses` in examples/error_printer

### DIFF
--- a/examples/error_printer.cpp
+++ b/examples/error_printer.cpp
@@ -17,6 +17,7 @@ namespace
 		"########## comments and whitespace"sv,
 		"# bar\rkek"sv,
 		"# bar\bkek"sv,
+		"# DEL character: '\x7f'"sv,
 		"# \xf1\x63"sv,
 		"# val1 = 1\fval2 = 2"sv,
 		"foo = 1\n\u2000\nbar = 2"sv,
@@ -115,11 +116,19 @@ namespace
 			}
 			else
 			{
-				if (c == '\\')
+				if (c == '\x7F')
 				{
-					std::cout << '\\';
+					// DEL character.
+					std::cout << "\\u007F"sv;
 				}
-				std::cout << c;
+				else
+				{
+					if (c == '\\')
+					{
+						std::cout << '\\';
+					}
+					std::cout << c;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What does this change do?**

It adds an example case to `invalid_parses` that has a DEL character, and it adjusts the local helper function `print_string` to display this character correctly.

**Is it related to an exisiting bug report or feature request?**

- It's a follow-up to pull request #259

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
