### PR TITLE
Address clang++20 nag about 'whitespace in literal operator'

### DIFF
--- a/include/toml++/impl/parser.hpp
+++ b/include/toml++/impl/parser.hpp
@@ -345,7 +345,7 @@ TOML_NAMESPACE_START
 		///				A toml::parse_result.
 		TOML_NODISCARD
 		TOML_ALWAYS_INLINE
-		parse_result operator"" _toml(const char* str, size_t len)
+		parse_result operator""_toml(const char* str, size_t len)
 		{
 			return parse(std::string_view{ str, len });
 		}
@@ -374,7 +374,7 @@ TOML_NAMESPACE_START
 		///				A toml::parse_result.
 		TOML_NODISCARD
 		TOML_ALWAYS_INLINE
-		parse_result operator"" _toml(const char8_t* str, size_t len)
+		parse_result operator""_toml(const char8_t* str, size_t len)
 		{
 			return parse(std::u8string_view{ str, len });
 		}

--- a/include/toml++/impl/path.hpp
+++ b/include/toml++/impl/path.hpp
@@ -790,7 +790,7 @@ TOML_NAMESPACE_START
 		/// \returns	A #toml::path generated from the string literal.
 		TOML_NODISCARD
 		TOML_ALWAYS_INLINE
-		path operator"" _tpath(const char* str, size_t len)
+		path operator""_tpath(const char* str, size_t len)
 		{
 			return path(std::string_view{ str, len });
 		}

--- a/tests/tests.hpp
+++ b/tests/tests.hpp
@@ -45,7 +45,7 @@ TOML_ENABLE_WARNINGS;
 TOML_NODISCARD
 TOML_ATTR(const)
 TOML_ALWAYS_INLINE
-constexpr size_t operator"" _sz(unsigned long long n) noexcept
+constexpr size_t operator""_sz(unsigned long long n) noexcept
 {
 	return static_cast<size_t>(n);
 }

--- a/toml.hpp
+++ b/toml.hpp
@@ -3658,7 +3658,7 @@ TOML_NAMESPACE_START
 	{
 		TOML_NODISCARD
 		TOML_ALWAYS_INLINE
-		path operator"" _tpath(const char* str, size_t len)
+		path operator""_tpath(const char* str, size_t len)
 		{
 			return path(std::string_view{ str, len });
 		}
@@ -9712,7 +9712,7 @@ TOML_NAMESPACE_START
 
 		TOML_NODISCARD
 		TOML_ALWAYS_INLINE
-		parse_result operator"" _toml(const char* str, size_t len)
+		parse_result operator""_toml(const char* str, size_t len)
 		{
 			return parse(std::string_view{ str, len });
 		}
@@ -9721,7 +9721,7 @@ TOML_NAMESPACE_START
 
 		TOML_NODISCARD
 		TOML_ALWAYS_INLINE
-		parse_result operator"" _toml(const char8_t* str, size_t len)
+		parse_result operator""_toml(const char8_t* str, size_t len)
 		{
 			return parse(std::u8string_view{ str, len });
 		}


### PR DESCRIPTION
As discussed in #261, `clang++-20` now nags about a whitespace after the `"""` in `operator""`.  A simple and sufficient change is to remove the whitespace. I have done so in `RcppTOM` and the CRAN repository for R which is already running some checks with `clang++-20` no longer tags the package.

I carried the same change over here.

Note that the embedded `catch` and `nlohmann::json` have the same issue in `operator "" ` (the initial whitespace between `operator` and `""` is apparently permitted) in a handful of places but as this is only used for testing I left it alone.

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)
