### PR TITLE
mention `TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,26 +203,27 @@ See [CONTRIBUTING] for information.
 A number of configurable options are exposed in the form of preprocessor `#defines` Most likely you
 won't need to mess with these at all, but if you do, set them before including toml++.
 
-| Option                            |      Type      | Description                                                                                               | Default               |
-| --------------------------------- | :------------: | --------------------------------------------------------------------------------------------------------- | --------------------- |
-| `TOML_ASSERT(expr)`               | function macro | Sets the assert function used by the library.                                                             | `assert()`            |
-| `TOML_CALLCONV`                   |     define     | Calling convention to apply to exported free/static functions.                                            | undefined             |
-| `TOML_CONFIG_HEADER`              | string literal | Includes the given header file before the rest of the library.                                            | undefined             |
-| `TOML_ENABLE_FORMATTERS`          |    boolean     | Enables the formatters. Set to `0` if you don't need them to improve compile times and binary size.       | `1`                   |
-| `TOML_ENABLE_FLOAT16`             |    boolean     | Enables support for the built-in `_Float16` type.                                                         | per compiler settings |
-| `TOML_ENABLE_PARSER`              |    boolean     | Enables the parser. Set to `0` if you don't need it to improve compile times and binary size.             | `1`                   |
-| `TOML_ENABLE_UNRELEASED_FEATURES` |    boolean     | Enables support for [unreleased TOML language features].                                                  | `0`                   |
-| `TOML_ENABLE_WINDOWS_COMPAT`      |    boolean     | Enables support for transparent conversion between wide and narrow strings.                               | `1` on Windows        |
-| `TOML_EXCEPTIONS`                 |    boolean     | Sets whether the library uses exceptions.                                                                 | per compiler settings |
-| `TOML_EXPORTED_CLASS`             |     define     | API export annotation to add to classes.                                                                  | undefined             |
-| `TOML_EXPORTED_MEMBER_FUNCTION`   |     define     | API export annotation to add to non-static class member functions.                                        | undefined             |
-| `TOML_EXPORTED_FREE_FUNCTION`     |     define     | API export annotation to add to free functions.                                                           | undefined             |
-| `TOML_EXPORTED_STATIC_FUNCTION`   |     define     | API export annotation to add to static functions.                                                         | undefined             |
-| `TOML_HEADER_ONLY`                |    boolean     | Disable this to explicitly control where toml++'s implementation is compiled (e.g. as part of a library). | `1`                   |
-| `TOML_IMPLEMENTATION`             |     define     | Define this to enable compilation of the library's implementation when `TOML_HEADER_ONLY` == `0`.         | undefined             |
-| `TOML_OPTIONAL_TYPE`              |   type name    | Overrides the `optional<T>` type used by the library if you need [something better than std::optional].   | undefined             |
-| `TOML_SMALL_FLOAT_TYPE`           |   type name    | If your codebase has a custom 'small float' type (e.g. half-precision), this tells toml++ about it.       | undefined             |
-| `TOML_SMALL_INT_TYPE`             |   type name    | If your codebase has a custom 'small integer' type (e.g. 24-bits), this tells toml++ about it.            | undefined             |
+| Option                                     |      Type      | Description                                                                                               | Default               |
+| ------------------------------------------ | :------------: | --------------------------------------------------------------------------------------------------------- | --------------------- |
+| `TOML_ASSERT(expr)`                        | function macro | Sets the assert function used by the library.                                                             | `assert()`            |
+| `TOML_CALLCONV`                            |     define     | Calling convention to apply to exported free/static functions.                                            | undefined             |
+| `TOML_CONFIG_HEADER`                       | string literal | Includes the given header file before the rest of the library.                                            | undefined             |
+| `TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA` |    boolean     | Disables the conditional `noexcept`'s of internal lambda's. Needed for MSVC's "legacy lambda processor".  | `0`                   |
+| `TOML_ENABLE_FORMATTERS`                   |    boolean     | Enables the formatters. Set to `0` if you don't need them to improve compile times and binary size.       | `1`                   |
+| `TOML_ENABLE_FLOAT16`                      |    boolean     | Enables support for the built-in `_Float16` type.                                                         | per compiler settings |
+| `TOML_ENABLE_PARSER`                       |    boolean     | Enables the parser. Set to `0` if you don't need it to improve compile times and binary size.             | `1`                   |
+| `TOML_ENABLE_UNRELEASED_FEATURES`          |    boolean     | Enables support for [unreleased TOML language features].                                                  | `0`                   |
+| `TOML_ENABLE_WINDOWS_COMPAT`               |    boolean     | Enables support for transparent conversion between wide and narrow strings.                               | `1` on Windows        |
+| `TOML_EXCEPTIONS`                          |    boolean     | Sets whether the library uses exceptions.                                                                 | per compiler settings |
+| `TOML_EXPORTED_CLASS`                      |     define     | API export annotation to add to classes.                                                                  | undefined             |
+| `TOML_EXPORTED_MEMBER_FUNCTION`            |     define     | API export annotation to add to non-static class member functions.                                        | undefined             |
+| `TOML_EXPORTED_FREE_FUNCTION`              |     define     | API export annotation to add to free functions.                                                           | undefined             |
+| `TOML_EXPORTED_STATIC_FUNCTION`            |     define     | API export annotation to add to static functions.                                                         | undefined             |
+| `TOML_HEADER_ONLY`                         |    boolean     | Disable this to explicitly control where toml++'s implementation is compiled (e.g. as part of a library). | `1`                   |
+| `TOML_IMPLEMENTATION`                      |     define     | Define this to enable compilation of the library's implementation when `TOML_HEADER_ONLY` == `0`.         | undefined             |
+| `TOML_OPTIONAL_TYPE`                       |   type name    | Overrides the `optional<T>` type used by the library if you need [something better than std::optional].   | undefined             |
+| `TOML_SMALL_FLOAT_TYPE`                    |   type name    | If your codebase has a custom 'small float' type (e.g. half-precision), this tells toml++ about it.       | undefined             |
+| `TOML_SMALL_INT_TYPE`                      |   type name    | If your codebase has a custom 'small integer' type (e.g. 24-bits), this tells toml++ about it.            | undefined             |
 
 > ℹ&#xFE0F; _A number of these have ABI implications; the library uses inline namespaces to prevent you from accidentally
 > linking incompatible combinations together._


### PR DESCRIPTION
**What does this change do?**

It adds  `TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA` to the table of configurable options, in README.md.

**Is it related to an existing bug report or feature request?**

- It's a follow-up to pull request #247


**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md

----

🤓  When reviewing, it may be helpful to hide whitespace changes: https://github.com/marzer/tomlplusplus/pull/269/files?w=1