### PR TITLE
fix: std::is_trivial is deprecated in C++26, replace to 'is_trivially_default_constructible_v && is_trivially_copyable_v'.

### DIFF
--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -182,7 +182,7 @@ TOML_ANON_NAMESPACE_START
 			return value;
 		}
 	};
-	static_assert(std::is_trivial_v<utf8_codepoint>);
+	static_assert(std::is_trivially_default_constructible_v<utf8_codepoint> && std::is_trivially_copyable_v<utf8_codepoint>);
 	static_assert(std::is_standard_layout_v<utf8_codepoint>);
 
 	struct TOML_ABSTRACT_INTERFACE utf8_reader_interface

--- a/toml.hpp
+++ b/toml.hpp
@@ -12750,7 +12750,7 @@ TOML_ANON_NAMESPACE_START
 			return value;
 		}
 	};
-	static_assert(std::is_trivial_v<utf8_codepoint>);
+	static_assert(std::is_trivially_default_constructible_v<utf8_codepoint> && std::is_trivially_copyable_v<utf8_codepoint>);
 	static_assert(std::is_standard_layout_v<utf8_codepoint>);
 
 	struct TOML_ABSTRACT_INTERFACE utf8_reader_interface


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->

**What does this change do?**

Changes std::is_trivial to std::is_trivially_default_constructible_v && std::is_trivially_copyable_v.


**Is it related to an exisiting bug report or feature request?**

no.

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [x] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
