### PR TITLE
TOML_DISABLE_NOEXCEPT_NOEXCEPT workaround MSVC bug noexcept + modules

### DIFF
--- a/include/toml++/impl/preprocessor.hpp
+++ b/include/toml++/impl/preprocessor.hpp
@@ -1252,6 +1252,22 @@ TOML_ENABLE_WARNINGS;
 /// These compile errors were reported by Kevin Dick, Jan 19, 2024, at https://github.com/marzer/tomlplusplus/issues/219
 //# }}
 
+#ifndef TOML_DISABLE_NOEXCEPT_NOEXCEPT
+#define TOML_DISABLE_NOEXCEPT_NOEXCEPT 0
+	#ifdef _MSC_VER
+		#if _MSC_VER <= 1943 // Up to Visual Studio 2022 Version 17.13.6
+		#undef TOML_DISABLE_NOEXCEPT_NOEXCEPT
+		#define TOML_DISABLE_NOEXCEPT_NOEXCEPT 1
+		#endif
+	#endif
+#endif
+//# {{
+/// \def TOML_DISABLE_NOEXCEPT_NOEXCEPT
+/// \brief Disable using noexcept(noexcept(<expression>)) within the toml++ library implementation.
+/// \detail This macro offers a workaround to a bug in Visual C++ (Visual Studio 2022), which caused
+/// compile errors, saying: "error C3878: syntax error: unexpected token ',' following 'simple-type-specifier'"
+//# }}
+
 /// @}
 //#====================================================================================================================
 //# CHARCONV SUPPORT

--- a/include/toml++/impl/value.hpp
+++ b/include/toml++/impl/value.hpp
@@ -266,8 +266,11 @@ TOML_NAMESPACE_START
 			(impl::value_variadic_ctor_allowed<value<ValueType>, impl::remove_cvref<Args>...>::value),
 			typename... Args)
 		TOML_NODISCARD_CTOR
-		explicit value(Args&&... args) noexcept(noexcept(value_type(
-			impl::native_value_maker<value_type, std::decay_t<Args>...>::make(static_cast<Args&&>(args)...))))
+		explicit value(Args&&... args)
+#if !TOML_DISABLE_NOEXCEPT_NOEXCEPT
+			noexcept(noexcept(value_type(
+				impl::native_value_maker<value_type, std::decay_t<Args>...>::make(static_cast<Args&&>(args)...))))
+#endif
 			: val_(impl::native_value_maker<value_type, std::decay_t<Args>...>::make(static_cast<Args&&>(args)...))
 		{
 #if TOML_LIFETIME_HOOKS

--- a/toml.hpp
+++ b/toml.hpp
@@ -1137,6 +1137,16 @@ TOML_ENABLE_WARNINGS;
 #define TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA 0
 #endif
 
+#ifndef TOML_DISABLE_NOEXCEPT_NOEXCEPT
+#define TOML_DISABLE_NOEXCEPT_NOEXCEPT 0
+	#ifdef _MSC_VER
+		#if _MSC_VER <= 1943 // Up to Visual Studio 2022 Version 17.13.6
+		#undef TOML_DISABLE_NOEXCEPT_NOEXCEPT
+		#define TOML_DISABLE_NOEXCEPT_NOEXCEPT 1
+		#endif
+	#endif
+#endif
+
 #if !defined(TOML_FLOAT_CHARCONV) && (TOML_GCC || TOML_CLANG || (TOML_ICC && !TOML_ICC_CL))
 // not supported by any version of GCC or Clang as of 26/11/2020
 // not supported by any version of ICC on Linux as of 11/01/2021
@@ -5088,8 +5098,11 @@ TOML_NAMESPACE_START
 			(impl::value_variadic_ctor_allowed<value<ValueType>, impl::remove_cvref<Args>...>::value),
 			typename... Args)
 		TOML_NODISCARD_CTOR
-		explicit value(Args&&... args) noexcept(noexcept(value_type(
-			impl::native_value_maker<value_type, std::decay_t<Args>...>::make(static_cast<Args&&>(args)...))))
+		explicit value(Args&&... args)
+#if !TOML_DISABLE_NOEXCEPT_NOEXCEPT
+			noexcept(noexcept(value_type(
+				impl::native_value_maker<value_type, std::decay_t<Args>...>::make(static_cast<Args&&>(args)...))))
+#endif
 			: val_(impl::native_value_maker<value_type, std::decay_t<Args>...>::make(static_cast<Args&&>(args)...))
 		{
 #if TOML_LIFETIME_HOOKS


### PR DESCRIPTION
**What does this change do?**

Allowed users of the tomlplusplus module to compile using MSVC.

Without `TOML_DISABLE_NOEXCEPT_NOEXCEPT`, MSVC appears to produce the following error:

> include\toml++\impl\value.hpp(270,39): error C3878: syntax error: unexpected token ',' following 'simple-type-specifier'
>    missing one of: '(' '{' ?
>    include\toml++\impl\value.hpp(270,39):
>    the template instantiation context (the oldest one first) is
>        include\toml++\impl\parser.inl(2757,26):
>        while compiling class template member function 'toml::v3::value<int64_t>::value<int64_t,0>(int64_t &&) noexcept(<expr>)'


**Is it related to an existing bug report or feature request?**

- It is another follow-up to pull request #266

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
