### PR TITLE
Fixed undefined behavior with log10 cast of fractional doubles

### DIFF
--- a/include/toml++/impl/toml_formatter.inl
+++ b/include/toml++/impl/toml_formatter.inl
@@ -91,7 +91,7 @@ TOML_ANON_NAMESPACE_START
 					weight += 1u;
 					val *= -1.0;
 				}
-				return weight + static_cast<size_t>(log10(val)) + 1u;
+				return weight + static_cast<size_t>(abs(log10(val))) + 1u;
 			}
 
 			case node_type::boolean: return 5u;

--- a/toml.hpp
+++ b/toml.hpp
@@ -17107,7 +17107,7 @@ TOML_ANON_NAMESPACE_START
 					weight += 1u;
 					val *= -1.0;
 				}
-				return weight + static_cast<size_t>(log10(val)) + 1u;
+				return weight + static_cast<size_t>(abs(log10(val))) + 1u;
 			}
 
 			case node_type::boolean: return 5u;


### PR DESCRIPTION
Fixed undefined behavior with log10 cast of fractional doubles.
Detected by UBSan

**What does this change do?**

Fixed undefined behavior with log10 cast of fractional doubles. log10 for values less than 1 result in a negative result, static-casting to size_t is undefined. 

**Is it related to an exisiting bug report or feature request?**

No. Example error:
```
external/tomlplusplus~/toml.hpp:16978:41: runtime error: -2.05916 is outside the range of representable values of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior external/tomlplusplus~/toml.hpp:16978:41
```

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [n/a] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [n/a] I've updated any affected documentation
-   [n/a] I've rebuilt and run the tests with at least one of:
    -   [n/a master is broken] Clang 8 or higher
    -   [n/a master is broken] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [n/a] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
