### PR TITLE
Fix missing include

### DIFF
--- a/include/toml++/impl/date_time.hpp
+++ b/include/toml++/impl/date_time.hpp
@@ -7,6 +7,7 @@
 #include "forward_declarations.hpp"
 #include "print_to_stream.hpp"
 #include "header_start.hpp"
+#include "std_optional.hpp"
 
 TOML_NAMESPACE_START
 {


### PR DESCRIPTION
date_time.hpp was not including std_optional.hpp directly. It probably got it transitively from other files including it directly. This caused clangd to complain at every `#include <toml++/toml.hpp>`

**What does this change do?**

Adds a missing include

**Is it related to an exisiting bug report or feature request?**

No

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x ] I've read [CONTRIBUTING.md]
-   [x ] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [ ] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
