### PR TITLE
fix: lower TOML_MAX_NESTED_VALUES to prevent stack overflow on deeply nested arrays/inline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ template:
 - fixed `is_homogeneous()` overloads with `first_nonmatch` outparam being broken in optimized builds (#231) (@Forbinn)
 - fixed unclear error message when parsing integers that would overflow (#224) (@chrimbo)
 - fixed CMake `install` target installing `meson.build` files (#236) (@JWCS)
+- lowered `TOML_MAX_NESTED_VALUES` default from 256 to 128 to prevent stack overflow on deeply nested arrays/inline tables in sanitizer builds (@danielbodorin)
 
 ## v3.4.0
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@bjadamson](https://github.com/bjadamson)** - Reported some bugs and helped design a new feature
 -   **[@bobfang1992](https://github.com/bobfang1992)** - Reported a bug and created a [wrapper in python](https://github.com/bobfang1992/pytomlpp)
 -   **[@capuanob](https://github.com/capuanob)** - Integrated this project into OSSFuzz
+-   **[@danielbodorin](https://github.com/danielbodorin)** - Fixed stack overflow from deeply nested arrays/inline tables
 -   **[@GiulioRomualdi](https://github.com/GiulioRomualdi)** - Added cmake+meson support
 -   **[@jonestristand](https://github.com/jonestristand)** - Designed and implemented the `toml::path`s feature
 -   **[@kcsaul](https://github.com/kcsaul)** - Fixed a bug

--- a/include/toml++/impl/preprocessor.hpp
+++ b/include/toml++/impl/preprocessor.hpp
@@ -1177,9 +1177,11 @@
 #endif
 
 #ifndef TOML_MAX_NESTED_VALUES
-#define TOML_MAX_NESTED_VALUES 256
+#define TOML_MAX_NESTED_VALUES 128
 // this refers to the depth of nested values, e.g. inline tables and arrays.
-// 256 is crazy high! if you're hitting this limit with real input, TOML is probably the wrong tool for the job...
+// 128 is very generous; real TOML files rarely exceed single-digit nesting.
+// keep this value low enough to avoid stack overflows in sanitizer-instrumented builds
+// where each recursion cycle may consume ~3KB of stack.
 #endif
 
 #ifndef TOML_MAX_DOTTED_KEYS_DEPTH

--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -168,6 +168,18 @@ b = []
 		constexpr auto start = "fl =[ "sv;
 		memcpy(s.data(), start.data(), start.length());
 		parsing_should_fail(FILE_LINE_ARGS, std::string_view{ s });
+
+		// deeply nested inline tables should also fail gracefully, not stack overflow
+		{
+			// build: fl = {a={a={a={a=...{a=1}...}}}
+			std::string nested_tables = "fl = ";
+			for (size_t i = 0; i < 2048; i++)
+				nested_tables += "{a=";
+			nested_tables += "1";
+			for (size_t i = 0; i < 2048; i++)
+				nested_tables += "}";
+			parsing_should_fail(FILE_LINE_ARGS, std::string_view{ nested_tables });
+		}
 	}
 
 	SECTION("tomlplusplus/issues/112") // https://github.com/marzer/tomlplusplus/issues/112

--- a/toml.hpp
+++ b/toml.hpp
@@ -1086,9 +1086,11 @@
 #endif
 
 #ifndef TOML_MAX_NESTED_VALUES
-#define TOML_MAX_NESTED_VALUES 256
+#define TOML_MAX_NESTED_VALUES 128
 // this refers to the depth of nested values, e.g. inline tables and arrays.
-// 256 is crazy high! if you're hitting this limit with real input, TOML is probably the wrong tool for the job...
+// 128 is very generous; real TOML files rarely exceed single-digit nesting.
+// keep this value low enough to avoid stack overflows in sanitizer-instrumented builds
+// where each recursion cycle may consume ~3KB of stack.
 #endif
 
 #ifndef TOML_MAX_DOTTED_KEYS_DEPTH


### PR DESCRIPTION
## What does this change do?

Lowers the default \TOML_MAX_NESTED_VALUES\ from 256 to 128 to prevent stack overflows when parsing deeply nested arrays (\[[[[...\) or inline tables (\{a={b={c=...\).

Each recursion cycle in \parse_array\ → \parse_value\ → \parse_array\ (and the equivalent \parse_inline_table\ path) consumes ~3,280 bytes of stack. At the previous default of 256:

- 256 × 3,280 = ~840KB — overflows 1MB stacks in sanitizer-instrumented builds (ASAN/MSAN)
- Observed crashes at ~191-310 recursion levels in OSS-Fuzz and Windows fuzzer builds

At the new default of 128:

- 128 × 3,280 = ~420KB — safe on 1MB stacks even under ASAN
- No real TOML document needs 128 levels of container nesting
- Users who need a different limit can still override via \#define TOML_MAX_NESTED_VALUES <N>\

PR #242 fixed a similar stack overflow for deeply nested **dotted keys** — this addresses the remaining **array/inline table** recursion path.

Fixes #292

## Is it related to an existing bug report or feature request?

Yes — #292

## Pre-merge checklist

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of \origin/master\
-   [x] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [x] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md]

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md