### PR TITLE
Set default value for deprecated option 'compile_library'

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@whiterabbit963](https://github.com/whiterabbit963)** - Fixed a bug with value_or conversions
 -   **[@ximion](https://github.com/ximion)** - Added support for installation with meson
 -   **[@rafal-c](https://github.com/rafal-c)** - Added a formatting flag
+-   **[@jfsimoneau](https://github.com/jfsimoneau)** - Fixed a meson option
 <br>
 
 ## Contact

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -11,5 +11,5 @@ option('unreleased_features',	type: 'boolean', value: false,	description: 'Enabl
 option('generate_cmake_config',	type: 'boolean', value: true,	description: 'Generate a cmake package config file (default: true - no effect when included as a subproject)')
 option('use_vendored_libs',		type: 'boolean', value: true,	description: 'Use the libs from the vendor dir when building tests.')
 
-option('compile_library',		type: 'boolean', deprecated: true)
+option('compile_library',		type: 'boolean', value: false,  deprecated: 'build_lib')
 option('float16',				type: 'boolean', deprecated: true)


### PR DESCRIPTION
**What does this change do?**

Set the default value for the deprecated meson option `compile_library` to false.

**Is it related to an exisiting bug report or feature request?**

No

**Pre-merge checklist**

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [ ] I've rebuilt and run the tests with at least one of:
    -   [ ] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
