### PR TITLE
Fix date_time.hpp error and header generator warnings

### DIFF
--- a/include/toml++/impl/date_time.hpp
+++ b/include/toml++/impl/date_time.hpp
@@ -4,8 +4,11 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#undef TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
+#undef TOML_DISABLE_NOEXCEPT_NOEXCEPT
 #include "forward_declarations.hpp"
 #include "print_to_stream.hpp"
+#include "std_optional.hpp"
 #include "header_start.hpp"
 
 TOML_NAMESPACE_START

--- a/include/toml++/impl/date_time.hpp
+++ b/include/toml++/impl/date_time.hpp
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#undef TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
-#undef TOML_DISABLE_NOEXCEPT_NOEXCEPT
 #include "forward_declarations.hpp"
 #include "print_to_stream.hpp"
 #include "std_optional.hpp"

--- a/toml.hpp
+++ b/toml.hpp
@@ -2715,9 +2715,6 @@ TOML_POP_WARNINGS;
 
 //********  impl/date_time.hpp  ****************************************************************************************
 
-#undef TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
-#undef TOML_DISABLE_NOEXCEPT_NOEXCEPT
-
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
 #ifndef __clang__

--- a/toml.hpp
+++ b/toml.hpp
@@ -2715,6 +2715,9 @@ TOML_POP_WARNINGS;
 
 //********  impl/date_time.hpp  ****************************************************************************************
 
+#undef TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA
+#undef TOML_DISABLE_NOEXCEPT_NOEXCEPT
+
 TOML_PUSH_WARNINGS;
 #ifdef _MSC_VER
 #ifndef __clang__

--- a/tools/generate_single_header.py
+++ b/tools/generate_single_header.py
@@ -242,7 +242,9 @@ def main():
 				r'TOML_UNDEF_MACROS',
 				r'TOMLPLUSPLUS_H',
 				r'TOMLPLUSPLUS_HPP',
-				r'TOML_SHARED_LIB'
+				r'TOML_SHARED_LIB',
+                r'TOML_DISABLE_CONDITIONAL_NOEXCEPT_LAMBDA',
+				r'TOML_DISABLE_NOEXCEPT_NOEXCEPT'
 			)
 			set_defines = []
 			for define, currently_set in defines.items():

--- a/tools/generate_single_header.py
+++ b/tools/generate_single_header.py
@@ -117,7 +117,7 @@ def main():
 			# blank lines between consecutive TOML_XXXXX_WARNINGS statements
 			toml_h = re.sub('(TOML_[A-Z_]+?_WARNINGS;)\n[ \t\n]*\n(TOML_[A-Z_]+?_WARNINGS;)', r'\1\n\2', toml_h)
 			# blank lines between consecutive #includes
-			toml_h = re.sub('[#]\s*include\s*<(.+?)>\n[ \t\n]*\n[#]\s*include\s*<(.+?)>', r'#include <\1>\n#include <\2>', toml_h)
+			toml_h = re.sub(r'[#]\s*include\s*<(.+?)>\n[ \t\n]*\n[#]\s*include\s*<(.+?)>', r'#include <\1>\n#include <\2>', toml_h)
 			# blank lines following opening brackets or a comma
 			toml_h = re.sub(r'([^@][({,])\n\n', r'\1\n', toml_h)
 			# blank lines preceeding closing brackets
@@ -129,7 +129,7 @@ def main():
 
 	# change TOML_LIB_SINGLE_HEADER to 1
 	toml_h = re.sub(
-		'#\s*define\s+TOML_LIB_SINGLE_HEADER\s+[0-9]+',
+		r'#\s*define\s+TOML_LIB_SINGLE_HEADER\s+[0-9]+',
 		'#define	TOML_LIB_SINGLE_HEADER 1',
 		toml_h, 0, re.I
 	)


### PR DESCRIPTION
<!--
    Please replace the HTML comments below with the requested information.
    Thanks for contributing!
-->

**What does this change do?**

<!-- 
This PR has the following changes:

- In Date_time.hpp mainly added #include "std_optional.hpp" at line 11. 

- Use of raw string literals at line 120 & 132 to fix Python regex escape warnings.

--->

**Is it related to an exisiting bug report or feature request?**

<!--
    No
--->

**Pre-merge checklist**

<!--
    Not all of these will necessarily apply, particularly if you're not making a code change (e.g. fixing documentation).
    That's OK. Tick the ones that do by placing an x in them, e.g. [x]
--->

-   [x] I've read [CONTRIBUTING.md]
-   [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [x] I've regenerated toml.hpp ([how-to])
-   [x] I've updated any affected documentation
-   [x] I've rebuilt and run the tests with at least one of:
    -   [x] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md
