### PR TITLE
Fix precondition violation in parse_key when parsing '[[[' table headers

### DIFF
--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -3157,6 +3157,16 @@ TOML_IMPL_NAMESPACE_START
 				if (*cp == U']')
 					set_error_and_return_default("tables with blank bare keys are explicitly prohibited"sv);
 
+				// the next character must be a valid key starter; otherwise parse_key()
+				// would be entered with an invalid precondition (e.g. for input like
+				// '[[[' the third '[' is neither a bare-key character nor a string
+				// delimiter). Reject explicitly here so we always raise a parse_error
+				// rather than tripping the precondition assertion in parse_key().
+				if (!is_bare_key_character(*cp) && !is_string_delimiter(*cp))
+					set_error_and_return_default("expected bare key starting character or string delimiter, saw '"sv,
+												 to_sv(*cp),
+												 "'"sv);
+
 				// get the actual key
 				start_recording();
 				parse_key();

--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -3157,11 +3157,6 @@ TOML_IMPL_NAMESPACE_START
 				if (*cp == U']')
 					set_error_and_return_default("tables with blank bare keys are explicitly prohibited"sv);
 
-				// the next character must be a valid key starter; otherwise parse_key()
-				// would be entered with an invalid precondition (e.g. for input like
-				// '[[[' the third '[' is neither a bare-key character nor a string
-				// delimiter). Reject explicitly here so we always raise a parse_error
-				// rather than tripping the precondition assertion in parse_key().
 				if (!is_bare_key_character(*cp) && !is_string_delimiter(*cp))
 					set_error_and_return_default("expected bare key starting character or string delimiter, saw '"sv,
 												 to_sv(*cp),

--- a/tests/parsing_tables.cpp
+++ b/tests/parsing_tables.cpp
@@ -20,6 +20,14 @@ TEST_CASE("parsing - tables")
 						   });
 	parsing_should_fail(FILE_LINE_ARGS, "[]"sv);
 
+	// Regression: '[[' followed by a non-key, non-']' character used to violate
+	// the precondition assertion in parse_key() (UB under NDEBUG, abort under
+	// debug). The parser must reject these as a normal parse error.
+	parsing_should_fail(FILE_LINE_ARGS, "[[[1]]]"sv);
+	parsing_should_fail(FILE_LINE_ARGS, "[[[a]]]"sv);
+	parsing_should_fail(FILE_LINE_ARGS, "[[[]]"sv);
+	parsing_should_fail(FILE_LINE_ARGS, "[[="sv);
+
 	// "Under that, and until the next header or EOF, are the key/values of that table.
 	//  Key/value pairs within tables are not guaranteed to be in any specific order."
 	parsing_should_succeed(FILE_LINE_ARGS,

--- a/tests/parsing_tables.cpp
+++ b/tests/parsing_tables.cpp
@@ -20,9 +20,6 @@ TEST_CASE("parsing - tables")
 						   });
 	parsing_should_fail(FILE_LINE_ARGS, "[]"sv);
 
-	// Regression: '[[' followed by a non-key, non-']' character used to violate
-	// the precondition assertion in parse_key() (UB under NDEBUG, abort under
-	// debug). The parser must reject these as a normal parse error.
 	parsing_should_fail(FILE_LINE_ARGS, "[[[1]]]"sv);
 	parsing_should_fail(FILE_LINE_ARGS, "[[[a]]]"sv);
 	parsing_should_fail(FILE_LINE_ARGS, "[[[]]"sv);

--- a/toml.hpp
+++ b/toml.hpp
@@ -15741,11 +15741,6 @@ TOML_IMPL_NAMESPACE_START
 				if (*cp == U']')
 					set_error_and_return_default("tables with blank bare keys are explicitly prohibited"sv);
 
-				// the next character must be a valid key starter; otherwise parse_key()
-				// would be entered with an invalid precondition (e.g. for input like
-				// '[[[' the third '[' is neither a bare-key character nor a string
-				// delimiter). Reject explicitly here so we always raise a parse_error
-				// rather than tripping the precondition assertion in parse_key().
 				if (!is_bare_key_character(*cp) && !is_string_delimiter(*cp))
 					set_error_and_return_default("expected bare key starting character or string delimiter, saw '"sv,
 												 to_sv(*cp),

--- a/toml.hpp
+++ b/toml.hpp
@@ -15741,6 +15741,16 @@ TOML_IMPL_NAMESPACE_START
 				if (*cp == U']')
 					set_error_and_return_default("tables with blank bare keys are explicitly prohibited"sv);
 
+				// the next character must be a valid key starter; otherwise parse_key()
+				// would be entered with an invalid precondition (e.g. for input like
+				// '[[[' the third '[' is neither a bare-key character nor a string
+				// delimiter). Reject explicitly here so we always raise a parse_error
+				// rather than tripping the precondition assertion in parse_key().
+				if (!is_bare_key_character(*cp) && !is_string_delimiter(*cp))
+					set_error_and_return_default("expected bare key starting character or string delimiter, saw '"sv,
+												 to_sv(*cp),
+												 "'"sv);
+
 				// get the actual key
 				start_recording();
 				parse_key();


### PR DESCRIPTION
## Description of the bug

`parse_table_header()` can call `parse_key()` with an invalid starting character after consuming a table header prefix.

For example, with input like `[[[1]]]`, the parser consumes the first `[` and the second `[` as an array-of-tables header, then enters `parse_key()` while `*cp` still points at the third `[`. That character is neither a bare-key character nor a string delimiter, so it violates this precondition in `parse_key()`:

```cpp
TOML_ASSERT_ASSUME(is_bare_key_character(*cp) || is_string_delimiter(*cp));
```

In debug builds this hits the assertion and aborts the process instead of returning a normal `parse_error`.

### Reproduction

```cpp
#include "toml++/toml.hpp"
int main()
{
    toml::parse("[[[1]]]");
}
```

With a debug clang build this currently fails with:

```text
Assertion failed: (is_bare_key_character(*cp) || is_string_delimiter(*cp)),
function parse_key, file parser.inl
```

Similar small cases are `[[[a]]]`, `[[[]]`, and `[[=`.

## Fix

Before calling `parse_key()`, `parse_table_header()` now checks that the next character is a valid key starter.
If it is not, the parser reports a normal `parse_error` instead of entering `parse_key()` with a broken precondition.

## Tests

Added regression tests for malformed array-of-table headers such as:

- `[[[1]]]`
- `[[[a]]]`
- `[[[]]`
- `[[=`

Valid table headers and array-of-table headers still parse as before.