### PR TITLE
fix(parser): preserve quoted-key text in redefinition error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@rafal-c](https://github.com/rafal-c)** - Added a formatting flag
 -   **[@jfsimoneau](https://github.com/jfsimoneau)** - Fixed a meson option
 -   **[@ShereeMorphett](https://github.com/ShereeMorphett)** - Fixed reinterpret_cast usage
+-   **[@SAY-5](https://github.com/SAY-5)** - Fixed a parser bug
 <br>
 
 ## Contact

--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -1686,10 +1686,7 @@ TOML_IMPL_NAMESPACE_START
 			TOML_ASSERT_ASSUME(is_string_delimiter(*cp));
 			push_parse_scope("string"sv);
 
-			// snapshot the recording buffer so we can rewind it alongside the input
-			// stream if the upcoming lookahead turns out to be a non-multi-line string
-			// (see go_back(2u) below). without this, the two lookahead code points end
-			// up recorded twice and pollute diagnostic messages (issue #300).
+			// snapshot length so the recording buffer can be rewound alongside go_back(2u) below
 			const auto recording_buffer_rollback_size = recording_buffer.length();
 
 			// get the first three characters to determine the string type
@@ -1722,10 +1719,6 @@ TOML_IMPL_NAMESPACE_START
 				// step back two characters so that the current
 				// character is the string delimiter
 				go_back(2u);
-
-				// rewind the recording buffer to mirror the input-stream rewind,
-				// otherwise the two lookahead code points get recorded a second time
-				// when the string is parsed for real (issue #300).
 				if (recording)
 					recording_buffer.resize(recording_buffer_rollback_size);
 

--- a/include/toml++/impl/parser.inl
+++ b/include/toml++/impl/parser.inl
@@ -1686,6 +1686,12 @@ TOML_IMPL_NAMESPACE_START
 			TOML_ASSERT_ASSUME(is_string_delimiter(*cp));
 			push_parse_scope("string"sv);
 
+			// snapshot the recording buffer so we can rewind it alongside the input
+			// stream if the upcoming lookahead turns out to be a non-multi-line string
+			// (see go_back(2u) below). without this, the two lookahead code points end
+			// up recorded twice and pollute diagnostic messages (issue #300).
+			const auto recording_buffer_rollback_size = recording_buffer.length();
+
 			// get the first three characters to determine the string type
 			const auto first = cp->value;
 			advance_and_return_if_error_or_eof({});
@@ -1716,6 +1722,12 @@ TOML_IMPL_NAMESPACE_START
 				// step back two characters so that the current
 				// character is the string delimiter
 				go_back(2u);
+
+				// rewind the recording buffer to mirror the input-stream rewind,
+				// otherwise the two lookahead code points get recorded a second time
+				// when the string is parsed for real (issue #300).
+				if (recording)
+					recording_buffer.resize(recording_buffer_rollback_size);
 
 				return { first == U'\'' ? parse_literal_string(false) : parse_basic_string(false), false };
 			}

--- a/tests/parsing_tables.cpp
+++ b/tests/parsing_tables.cpp
@@ -301,6 +301,37 @@ TEST_CASE("parsing - tables")
 						   });
 }
 
+TEST_CASE("parsing - redefinition error messages preserve quoted keys")
+{
+	// https://github.com/marzer/tomlplusplus/issues/300
+	// quoted-key redefinition error messages used to contain a corrupted key (e.g. "fofoo"
+	// instead of "foo") because the parse_string lookahead recorded two extra code points
+	// into the diagnostic recording buffer that were never rewound on the non-multi-line path.
+	static constexpr auto src = "[\"foo\"]\nx = 1\n[\"foo\"]\ny = 2\n"sv;
+#if TOML_EXCEPTIONS
+	std::string desc;
+	bool threw = false;
+	try
+	{
+		[[maybe_unused]] auto res = toml::parse(src);
+	}
+	catch (const toml::parse_error& err)
+	{
+		threw = true;
+		desc.assign(err.description());
+	}
+	REQUIRE(threw);
+	CHECK(desc.find("\"foo\"") != std::string::npos);
+	CHECK(desc.find("fofoo") == std::string::npos);
+#else
+	auto result = toml::parse(src);
+	REQUIRE(!result);
+	const std::string desc{ result.error().description() };
+	CHECK(desc.find("\"foo\"") != std::string::npos);
+	CHECK(desc.find("fofoo") == std::string::npos);
+#endif
+}
+
 TEST_CASE("parsing - inline tables")
 {
 	// these are the examples from https://toml.io/en/v1.0.0#inline-table

--- a/tests/parsing_tables.cpp
+++ b/tests/parsing_tables.cpp
@@ -304,9 +304,6 @@ TEST_CASE("parsing - tables")
 TEST_CASE("parsing - redefinition error messages preserve quoted keys")
 {
 	// https://github.com/marzer/tomlplusplus/issues/300
-	// quoted-key redefinition error messages used to contain a corrupted key (e.g. "fofoo"
-	// instead of "foo") because the parse_string lookahead recorded two extra code points
-	// into the diagnostic recording buffer that were never rewound on the non-multi-line path.
 	static constexpr auto src = "[\"foo\"]\nx = 1\n[\"foo\"]\ny = 2\n"sv;
 #if TOML_EXCEPTIONS
 	std::string desc;

--- a/toml.hpp
+++ b/toml.hpp
@@ -14271,6 +14271,12 @@ TOML_IMPL_NAMESPACE_START
 			TOML_ASSERT_ASSUME(is_string_delimiter(*cp));
 			push_parse_scope("string"sv);
 
+			// snapshot the recording buffer so we can rewind it alongside the input
+			// stream if the upcoming lookahead turns out to be a non-multi-line string
+			// (see go_back(2u) below). without this, the two lookahead code points end
+			// up recorded twice and pollute diagnostic messages (issue #300).
+			const auto recording_buffer_rollback_size = recording_buffer.length();
+
 			// get the first three characters to determine the string type
 			const auto first = cp->value;
 			advance_and_return_if_error_or_eof({});
@@ -14301,6 +14307,12 @@ TOML_IMPL_NAMESPACE_START
 				// step back two characters so that the current
 				// character is the string delimiter
 				go_back(2u);
+
+				// rewind the recording buffer to mirror the input-stream rewind,
+				// otherwise the two lookahead code points get recorded a second time
+				// when the string is parsed for real (issue #300).
+				if (recording)
+					recording_buffer.resize(recording_buffer_rollback_size);
 
 				return { first == U'\'' ? parse_literal_string(false) : parse_basic_string(false), false };
 			}

--- a/toml.hpp
+++ b/toml.hpp
@@ -14271,10 +14271,7 @@ TOML_IMPL_NAMESPACE_START
 			TOML_ASSERT_ASSUME(is_string_delimiter(*cp));
 			push_parse_scope("string"sv);
 
-			// snapshot the recording buffer so we can rewind it alongside the input
-			// stream if the upcoming lookahead turns out to be a non-multi-line string
-			// (see go_back(2u) below). without this, the two lookahead code points end
-			// up recorded twice and pollute diagnostic messages (issue #300).
+			// snapshot length so the recording buffer can be rewound alongside go_back(2u) below
 			const auto recording_buffer_rollback_size = recording_buffer.length();
 
 			// get the first three characters to determine the string type
@@ -14307,10 +14304,6 @@ TOML_IMPL_NAMESPACE_START
 				// step back two characters so that the current
 				// character is the string delimiter
 				go_back(2u);
-
-				// rewind the recording buffer to mirror the input-stream rewind,
-				// otherwise the two lookahead code points get recorded a second time
-				// when the string is parsed for real (issue #300).
 				if (recording)
 					recording_buffer.resize(recording_buffer_rollback_size);
 


### PR DESCRIPTION
**What does this change do?**

Fixes the corrupted quoted-key string that appears in redefinition error messages. A key written as `["foo"]` previously produced an error of the form `cannot redefine existing table '"fofoo"'`. With this change the diagnostic shows `"foo"`, as written in the source.

**Is it related to an exisiting bug report or feature request?**

Fixes #300.

**Pre-merge checklist**

- [x] I've read [CONTRIBUTING.md]
- [x] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
- [x] I've added new test cases to verify my change
- [x] I've regenerated toml.hpp ([how-to])
- [ ] I've updated any affected documentation
- [x] I've rebuilt and run the tests with at least one of:
    - [ ] Clang 8 or higher
    - [x] GCC 8 or higher
    - [ ] MSVC 19.20 (Visual Studio 2019) or higher
- [x] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)

[CONTRIBUTING.md]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md
[how-to]: https://github.com/marzer/tomlplusplus/blob/master/CONTRIBUTING.md#regenerating-tomlhpp
[README.md]: https://github.com/marzer/tomlplusplus/blob/master/README.md