### PR TITLE
Remove duplicate CMake in modules implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ UTF-8 decoding is performed using a state machine based on Bjoern Hoehrmann's '[
 -   **[@bobfang1992](https://github.com/bobfang1992)** - Reported a bug and created a [wrapper in python](https://github.com/bobfang1992/pytomlpp)
 -   **[@capuanob](https://github.com/capuanob)** - Integrated this project into OSSFuzz
 -   **[@danielbodorin](https://github.com/danielbodorin)** - Fixed stack overflow from deeply nested arrays/inline tables
+-   **[@davidstone](http://github.com/davidstone)** - Fixed bug in CMake for modules support
 -   **[@GiulioRomualdi](https://github.com/GiulioRomualdi)** - Added cmake+meson support
 -   **[@jonestristand](https://github.com/jonestristand)** - Designed and implemented the `toml::path`s feature
 -   **[@kcsaul](https://github.com/kcsaul)** - Fixed a bug

--- a/src/modules/CMakeLists.txt
+++ b/src/modules/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.28)
+
 file(GLOB_RECURSE TOMLPLUSPLUS_MODULES *.cppm)
 
 add_library(tomlplusplus_modules)
@@ -6,21 +8,6 @@ target_sources(tomlplusplus_modules
     FILE_SET CXX_MODULES FILES
     ${TOMLPLUSPLUS_MODULES}
 )
-
-cmake_minimum_required(VERSION 3.28)
-
-if(NOT COMMAND configure_cpp_module_target)
-  function(configure_cpp_module_target target)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.28)
-      target_sources(${target} PUBLIC FILE_SET CXX_MODULES FILES ${TOMLPLUSPLUS_MODULES})
-    else()
-      message(WARNING "C++ modules require CMake 3.28+. Using standard compilation.")
-      target_sources(${target} PRIVATE ${TOMLPLUSPLUS_MODULES})
-    endif()
-  endfunction()
-endif()
-
-configure_cpp_module_target(tomlplusplus_modules)
 
 target_link_libraries(tomlplusplus_modules
   PUBLIC


### PR DESCRIPTION
It looks like two different approaches to the same problem got committed to this file. Remove the more complicated approach and keep the simpler approach. This fixes CMake warnings about the same source file appearing multiple times.

**Pre-merge checklist**

-   [X] I've read [CONTRIBUTING.md]
-   [X] I've rebased my changes against the current HEAD of `origin/master` (if necessary)
-   [ ] I've added new test cases to verify my change
-   [ ] I've regenerated toml.hpp ([how-to])
-   [ ] I've updated any affected documentation
-   [X] I've rebuilt and run the tests with at least one of:
    -   [X] Clang 8 or higher
    -   [ ] GCC 8 or higher
    -   [ ] MSVC 19.20 (Visual Studio 2019) or higher
-   [X] I've added my name to the list of contributors in [README.md](https://github.com/marzer/tomlplusplus/blob/master/README.md)
