### PR TITLE
Return false for non-whitespace Unicode code points

### DIFF
--- a/include/toml++/impl/unicode_autogenerated.hpp
+++ b/include/toml++/impl/unicode_autogenerated.hpp
@@ -41,10 +41,8 @@ TOML_IMPL_NAMESPACE_START
 			case 0x05: return c == U'\u1680' || c == U'\u180E';
 			case 0x07:
 				return (U'\u2000' <= c && c <= U'\u200B') || (U'\u205F' <= c && c <= U'\u2060') || c == U'\u202F';
-			default: TOML_UNREACHABLE;
+			default: return false;
 		}
-
-		TOML_UNREACHABLE;
 	}
 
 	TOML_CONST_GETTER

--- a/tests/user_feedback.cpp
+++ b/tests/user_feedback.cpp
@@ -182,6 +182,12 @@ b = []
 		}
 	}
 
+	SECTION("tomlplusplus/issues/295") // https://github.com/marzer/tomlplusplus/issues/295
+	{
+		parsing_should_fail(FILE_LINE_ARGS, "\xcc\xaa"sv);
+		parsing_should_fail(FILE_LINE_ARGS, "\xcf\xaa"sv);
+	}
+
 	SECTION("tomlplusplus/issues/112") // https://github.com/marzer/tomlplusplus/issues/112
 	{
 		parsing_should_fail(FILE_LINE_ARGS,

--- a/toml.hpp
+++ b/toml.hpp
@@ -8809,10 +8809,8 @@ TOML_IMPL_NAMESPACE_START
 			case 0x05: return c == U'\u1680' || c == U'\u180E';
 			case 0x07:
 				return (U'\u2000' <= c && c <= U'\u200B') || (U'\u205F' <= c && c <= U'\u2060') || c == U'\u202F';
-			default: TOML_UNREACHABLE;
+			default: return false;
 		}
-
-		TOML_UNREACHABLE;
 	}
 
 	TOML_CONST_GETTER


### PR DESCRIPTION
Fixes #295.

The horizontal-whitespace lookup can reach its default case for code points that are not whitespace. Return false there, matching the existing explicit cases, so parsing reports an input error normally.

- [x] Read CONTRIBUTING.md
- [x] Added regression cases
- [x] Regenerated toml.hpp
- [x] Rebuilt and ran tests with GCC 15.2 on Windows (55 test cases, 47782 assertions with LC_ALL=C)
- [ ] Updated documentation (not needed)